### PR TITLE
Fix failing tests under PHP5

### DIFF
--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -73,7 +73,7 @@ class GenerateDocumentation extends Command
         } else {
             $parsedRoutes = $this->processDingoRoutes($generator, $allowedRoutes, $routePrefix);
         }
-        $parsedRoutes = collect($parsedRoutes)->sortBy('resource')->groupBy('resource');
+        $parsedRoutes = collect($parsedRoutes)->groupBy('resource')->sortBy('resource');
 
         $this->writeMarkdown($parsedRoutes);
     }


### PR DESCRIPTION
Well, under PHP7 all tests has been passed successfully. But under PHP5, the same tests fail miserably. This happens for the behavior of `asort` function when we try to sort an array with duplicated key values.

![captura](https://cloud.githubusercontent.com/assets/9524225/16579152/c5763f0e-4274-11e6-9dfa-0875ea4ac92a.JPG)

In `GenerateDocumentation.php`, we sort the items first and then we group them by resource. In this way, if we have routes with same resource the order is unpredectable.

In order to eliminate duplications, we can group the items by resource and finally sort them.


With this change, we will be obtaining the same results in both PHP versions.