### PR TITLE
FIX: Error generating documentation with Dingo API

### DIFF
--- a/src/resources/views/documentarian.blade.php
+++ b/src/resources/views/documentarian.blade.php
@@ -66,7 +66,11 @@ console.log(response);
 > Example response:
 
 ```json
+@if(is_object($parsedRoute['response']) || is_array($parsedRoute['response']))
+{!! json_encode($parsedRoute['response'], JSON_PRETTY_PRINT) !!}
+@else
 {!! json_encode(json_decode($parsedRoute['response']), JSON_PRETTY_PRINT) !!}
+@endif
 ```
 @endif
 


### PR DESCRIPTION
Fixed "PHP Fatal error: Method Illuminate\View\View::__toString(……) must not throw an exception" when using with Dingo API.