### PR TITLE
Response example for routes with parameters

### DIFF
--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -77,7 +77,7 @@ abstract class AbstractGenerator
         })->collapse()->toArray();
 
         //Changes url with parameters like /users/{user} to /users/1
-        $uri =  preg_replace("/{(.*)}/", 1, $uri);
+        $uri =  preg_replace('/{(.*)}/', 1, $uri);
         
         return $this->callRoute(array_shift($methods), $uri, [], [], [], $headers);
     }

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -78,7 +78,7 @@ abstract class AbstractGenerator
 
         //Changes url with parameters like /users/{user} to /users/1
         $uri = preg_replace('/{(.*)}/', 1, $uri);
-        
+
         return $this->callRoute(array_shift($methods), $uri, [], [], [], $headers);
     }
 

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -77,7 +77,7 @@ abstract class AbstractGenerator
         })->collapse()->toArray();
 
         //Changes url with parameters like /users/{user} to /users/1
-        $uri =  preg_replace('/{(.*)}/', 1, $uri);
+        $uri = preg_replace('/{(.*)}/', 1, $uri);
         
         return $this->callRoute(array_shift($methods), $uri, [], [], [], $headers);
     }

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -76,6 +76,9 @@ abstract class AbstractGenerator
             return [trim($split[0]) => trim($split[1])];
         })->collapse()->toArray();
 
+        //Changes url with parameters like /users/{user} to /users/1
+        $uri =  preg_replace("/{(.*)}/", 1, $uri);
+        
         return $this->callRoute(array_shift($methods), $uri, [], [], [], $headers);
     }
 


### PR DESCRIPTION
Now example response works only for resource `index` methods (/users), and for `show` methods it sends wrong parameter to route.
I added fix for it, so now example response will be available for urls like `/users/{user}` => `/users/1` or `/users/{user}/page/[page}` => `/users/1/page/1`