### PR TITLE
Fix so that grouping is sorted alphabetically

### DIFF
--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -81,7 +81,9 @@ class GenerateDocumentation extends Command
         } else {
             $parsedRoutes = $this->processDingoRoutes($generator, $allowedRoutes, $routePrefix, $middleware);
         }
-        $parsedRoutes = collect($parsedRoutes)->groupBy('resource')->sortBy('resource');
+        $parsedRoutes = collect($parsedRoutes)->groupBy('resource')->sort(function ($a, $b) {
+            return strcmp($a->first()['resource'], $b->first()['resource']);
+        });
 
         $this->writeMarkdown($parsedRoutes);
     }


### PR DESCRIPTION
Changing the order of the sortby and groupby will allow the groups to be sorted in alphabetical order.

This is a very minor fix, and I believe was the original intention of this line of code.