### PR TITLE
Laravel 5.4 compatibility

### DIFF
--- a/src/Mpociot/ApiDoc/ApiDocGeneratorServiceProvider.php
+++ b/src/Mpociot/ApiDoc/ApiDocGeneratorServiceProvider.php
@@ -31,10 +31,10 @@ class ApiDocGeneratorServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['apidoc.generate'] = $this->app->share(function () {
+        $this->app->singleton('apidoc.generate', function () {
             return new GenerateDocumentation();
         });
-        $this->app['apidoc.update'] = $this->app->share(function () {
+        $this->app->singleton('apidoc.update', function () {
             return new UpdateDocumentation();
         });
 

--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -259,9 +259,9 @@ class GenerateDocumentation extends Command
             if (in_array($route->getName(), $allowedRoutes) || str_is($routePrefix, $route->uri()) || in_array($middleware, $route->middleware())) {
                 if ($this->isValidRoute($route) && $this->isRouteVisibleForDocumentation($route->getAction()['uses'])) {
                     $parsedRoutes[] = $generator->processRoute($route, $bindings, $this->option('header'), $withResponse);
-                    $this->info('Processed route: ['.implode(',', $route->getMethods()).'] '.$route->uri());
+                    $this->info('Processed route: ['.implode(',', $route->methods()).'] '.$route->uri());
                 } else {
-                    $this->warn('Skipping route: ['.implode(',', $route->getMethods()).'] '.$route->uri());
+                    $this->warn('Skipping route: ['.implode(',', $route->methods()).'] '.$route->uri());
                 }
             }
         }
@@ -286,9 +286,9 @@ class GenerateDocumentation extends Command
             if (empty($allowedRoutes) || in_array($route->getName(), $allowedRoutes) || str_is($routePrefix, $route->uri()) || in_array($middleware, $route->middleware())) {
                 if ($this->isValidRoute($route) && $this->isRouteVisibleForDocumentation($route->getAction()['uses'])) {
                     $parsedRoutes[] = $generator->processRoute($route, $bindings, $this->option('header'), $withResponse);
-                    $this->info('Processed route: ['.implode(',', $route->getMethods()).'] '.$route->uri());
+                    $this->info('Processed route: ['.implode(',', $route->methods()).'] '.$route->uri());
                 } else {
-                    $this->warn('Skipping route: ['.implode(',', $route->getMethods()).'] '.$route->uri());
+                    $this->warn('Skipping route: ['.implode(',', $route->methods()).'] '.$route->uri());
                 }
             }
         }

--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -256,12 +256,12 @@ class GenerateDocumentation extends Command
         $bindings = $this->getBindings();
         $parsedRoutes = [];
         foreach ($routes as $route) {
-            if (in_array($route->getName(), $allowedRoutes) || str_is($routePrefix, $route->getUri()) || in_array($middleware, $route->middleware())) {
+            if (in_array($route->getName(), $allowedRoutes) || str_is($routePrefix, $route->uri()) || in_array($middleware, $route->middleware())) {
                 if ($this->isValidRoute($route) && $this->isRouteVisibleForDocumentation($route->getAction()['uses'])) {
                     $parsedRoutes[] = $generator->processRoute($route, $bindings, $this->option('header'), $withResponse);
-                    $this->info('Processed route: ['.implode(',', $route->getMethods()).'] '.$route->getUri());
+                    $this->info('Processed route: ['.implode(',', $route->getMethods()).'] '.$route->uri());
                 } else {
-                    $this->warn('Skipping route: ['.implode(',', $route->getMethods()).'] '.$route->getUri());
+                    $this->warn('Skipping route: ['.implode(',', $route->getMethods()).'] '.$route->uri());
                 }
             }
         }

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -76,7 +76,7 @@ abstract class AbstractGenerator
     {
         $uri = $this->addRouteModelBindings($route, $bindings);
 
-        $methods = $route->getMethods();
+        $methods = $route->methods();
 
         // Split headers into key - value pairs
         $headers = collect($headers)->map(function ($value) {

--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -46,11 +46,11 @@ class LaravelGenerator extends AbstractGenerator
         }
 
         return $this->getParameters([
-            'id' => md5($route->uri().':'.implode($route->getMethods())),
+            'id' => md5($route->uri().':'.implode($route->methods())),
             'resource' => $routeGroup,
             'title' => $routeDescription['short'],
             'description' => $routeDescription['long'],
-            'methods' => $route->getMethods(),
+            'methods' => $route->methods(),
             'uri' => $route->uri(),
             'parameters' => [],
             'response' => $content,

--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -17,7 +17,7 @@ class LaravelGenerator extends AbstractGenerator
      */
     protected function getUri($route)
     {
-        return $route->getUri();
+        return $route->uri();
     }
 
     /**
@@ -46,12 +46,12 @@ class LaravelGenerator extends AbstractGenerator
         }
 
         return $this->getParameters([
-            'id' => md5($route->getUri().':'.implode($route->getMethods())),
+            'id' => md5($route->uri().':'.implode($route->getMethods())),
             'resource' => $routeGroup,
             'title' => $routeDescription['short'],
             'description' => $routeDescription['long'],
             'methods' => $route->getMethods(),
-            'uri' => $route->getUri(),
+            'uri' => $route->uri(),
             'parameters' => [],
             'response' => $content,
         ], $routeAction, $bindings);


### PR DESCRIPTION
Laravel 5.4 has removed a few legacy methods, so this is just a pull request to bring back the compatibility.

- Replaced the `share()` method with `singleton()`
- Replace `getUri()` method with `uri()`
- Replace `getMethods()` method with `methods()`

There is one failing test, but this was failing before I made these changes.