### PR TITLE
Update AbstractGenerator.php

### DIFF
--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -308,7 +308,7 @@ abstract class AbstractGenerator
             case 'digits':
                 $attributeData['type'] = 'numeric';
                 $attributeData['description'][] = Description::parse($rule)->with($parameters)->getDescription();
-                $attributeData['value'] = $faker->randomNumber($parameters[0], true);
+                $attributeData['value'] = ($parameters[0] < 9) ? $faker->randomNumber($parameters[0], true) : substr(mt_rand(100000000, mt_getrandmax()), 0, $parameters[0]);
                 break;
             case 'digits_between':
                 $attributeData['type'] = 'numeric';


### PR DESCRIPTION
The built in faker->randomNumber freaks out on `digits:10`, commonly seen on phone number validation. This is directionally where I'd send it, but maybe not the cleanest execution. But the basic idea is that if the length of digits being randomized is less than 9, proceed as previous, greater than that, use mt_rand() from 1,000,000,000 up to mt_randmax(), which incidentally, is still a 10 digit number... and then take the substr starting at pos{0}, and ending at the desired digit length. 

Maybe a specific regex is in order?