### PR TITLE
Support for query parameters

### DIFF
--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -152,7 +152,7 @@ abstract class AbstractGenerator
 
         $parametersTag = $phpdoc->getTagsByName('queryParameters');
         if ($parametersTag) {
-            $routeParameters = array_flip(explode(',', trim($parametersTag[0]->getContent(), "[]")));
+            $routeParameters = array_flip(explode(',', trim($parametersTag[0]->getContent(), '[]')));
             return array_intersect_key($parameters, $routeParameters);
         }
         return [];

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -153,8 +153,10 @@ abstract class AbstractGenerator
         $parametersTag = $phpdoc->getTagsByName('queryParameters');
         if ($parametersTag) {
             $routeParameters = array_flip(explode(',', trim($parametersTag[0]->getContent(), '[]')));
+
             return array_intersect_key($parameters, $routeParameters);
         }
+
         return [];
     }
 

--- a/src/Mpociot/ApiDoc/Generators/DingoGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/DingoGenerator.php
@@ -10,17 +10,20 @@ class DingoGenerator extends AbstractGenerator
      * @param \Illuminate\Routing\Route $route
      * @param array $bindings
      * @param array $headers
+     * @param array $parameters
      * @param bool $withResponse
      *
      * @return array
      */
-    public function processRoute($route, $bindings = [], $headers = [], $withResponse = true)
+    public function processRoute($route, $bindings = [], $headers = [], $parameters = [], $withResponse = true)
     {
         $response = '';
+        $routeParameters = $this->getRouteQueryParams($routeAction['uses'], $parameters);
+        $queryString = $routeParameters ? '?' . http_build_query($routeParameters) : '';
 
         if ($withResponse) {
             try {
-                $response = $this->getRouteResponse($route, $bindings, $headers);
+                $response = $this->getRouteResponse($route, $bindings, $headers, $routeParameters);
             } catch (Exception $e) {
             }
         }
@@ -35,8 +38,8 @@ class DingoGenerator extends AbstractGenerator
             'title' => $routeDescription['short'],
             'description' => $routeDescription['long'],
             'methods' => $route->getMethods(),
-            'uri' => $route->uri(),
-            'parameters' => [],
+            'uri' => $route->uri() . $queryString,
+            'parameters' => $parameters,
             'response' => $response,
         ], $routeAction, $bindings);
     }

--- a/src/Mpociot/ApiDoc/Generators/DingoGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/DingoGenerator.php
@@ -19,7 +19,7 @@ class DingoGenerator extends AbstractGenerator
     {
         $response = '';
         $routeParameters = $this->getRouteQueryParams($routeAction['uses'], $parameters);
-        $queryString = $routeParameters ? '?' . http_build_query($routeParameters) : '';
+        $queryString = $routeParameters ? '?'.http_build_query($routeParameters) : '';
 
         if ($withResponse) {
             try {
@@ -38,7 +38,7 @@ class DingoGenerator extends AbstractGenerator
             'title' => $routeDescription['short'],
             'description' => $routeDescription['long'],
             'methods' => $route->getMethods(),
-            'uri' => $route->uri() . $queryString,
+            'uri' => $route->uri().$queryString,
             'parameters' => $parameters,
             'response' => $response,
         ], $routeAction, $bindings);

--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -15,13 +15,14 @@ class LaravelGenerator extends AbstractGenerator
      *
      * @return mixed
      */
-    public function getUri($route)
+    public function getUri($route, $routeParameters = [])
     {
+        $queryString = $routeParameters ? '?' . http_build_query($routeParameters) : '';
         if (version_compare(app()->version(), '5.4', '<')) {
-            return $route->getUri();
+            return $route->getUri() . $queryString;
         }
 
-        return $route->uri();
+        return $route->uri() . $queryString;
     }
 
     /**
@@ -42,20 +43,21 @@ class LaravelGenerator extends AbstractGenerator
      * @param  \Illuminate\Routing\Route $route
      * @param array $bindings
      * @param array $headers
+     * @param array $parameters
      * @param bool $withResponse
      *
      * @return array
      */
-    public function processRoute($route, $bindings = [], $headers = [], $withResponse = true)
+    public function processRoute($route, $bindings = [], $headers = [], $parameters = [], $withResponse = true)
     {
         $content = '';
-
         $routeAction = $route->getAction();
         $routeGroup = $this->getRouteGroup($routeAction['uses']);
         $routeDescription = $this->getRouteDescription($routeAction['uses']);
+        $routeParameters = $this->getRouteQueryParams($routeAction['uses'], $parameters);
 
         if ($withResponse) {
-            $response = $this->getRouteResponse($route, $bindings, $headers);
+            $response = $this->getRouteResponse($route, $bindings, $headers, $routeParameters);
             if ($response->headers->get('Content-Type') === 'application/json') {
                 $content = json_encode(json_decode($response->getContent()), JSON_PRETTY_PRINT);
             } else {
@@ -69,7 +71,7 @@ class LaravelGenerator extends AbstractGenerator
             'title' => $routeDescription['short'],
             'description' => $routeDescription['long'],
             'methods' => $this->getMethods($route),
-            'uri' => $this->getUri($route),
+            'uri' => $this->getUri($route, $routeParameters),
             'parameters' => [],
             'response' => $content,
         ], $routeAction, $bindings);

--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -19,7 +19,7 @@ class LaravelGenerator extends AbstractGenerator
     {
         $queryString = $routeParameters ? '?'.http_build_query($routeParameters) : '';
         if (version_compare(app()->version(), '5.4', '<')) {
-            return $route->getUri() . $queryString;
+            return $route->getUri().$queryString;
         }
 
         return $route->uri().$queryString;

--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -17,12 +17,12 @@ class LaravelGenerator extends AbstractGenerator
      */
     public function getUri($route, $routeParameters = [])
     {
-        $queryString = $routeParameters ? '?' . http_build_query($routeParameters) : '';
+        $queryString = $routeParameters ? '?'.http_build_query($routeParameters) : '';
         if (version_compare(app()->version(), '5.4', '<')) {
             return $route->getUri() . $queryString;
         }
 
-        return $route->uri() . $queryString;
+        return $route->uri().$queryString;
     }
 
     /**

--- a/src/resources/views/partials/route.blade.php
+++ b/src/resources/views/partials/route.blade.php
@@ -10,7 +10,7 @@
 > Example request:
 
 ```bash
-curl -X {{$parsedRoute['methods'][0]}} "{{config('app.url')}}/{{$parsedRoute['uri']}}" \
+curl -X {{$parsedRoute['methods'][0]}} "{{config('app.docs_url') ?: config('app.url')}}/{!! $parsedRoute['uri'] !!}" \
 -H "Accept: application/json"@if(count($parsedRoute['parameters'])) \
 @foreach($parsedRoute['parameters'] as $attribute => $parameter)
     -d "{{$attribute}}"="{{$parameter['value']}}" \
@@ -23,7 +23,7 @@ curl -X {{$parsedRoute['methods'][0]}} "{{config('app.url')}}/{{$parsedRoute['ur
 var settings = {
     "async": true,
     "crossDomain": true,
-    "url": "{{config('app.url')}}/{{$parsedRoute['uri']}}",
+    "url": "{{config('app.docs_url') ?: config('app.url')}}/{!! $parsedRoute['uri'] !!}",
     "method": "{{$parsedRoute['methods'][0]}}",
     @if(count($parsedRoute['parameters']))
 "data": {!! str_replace('    ','        ',json_encode(array_combine(array_keys($parsedRoute['parameters']), array_map(function($param){ return $param['value']; },$parsedRoute['parameters'])), JSON_PRETTY_PRINT)) !!},
@@ -52,7 +52,7 @@ $.ajax(settings).done(function (response) {
 
 ### HTTP Request
 @foreach($parsedRoute['methods'] as $method)
-`{{$method}} {{$parsedRoute['uri']}}`
+`{{$method}} {!! $parsedRoute['uri'] !!}`
 
 @endforeach
 @if(count($parsedRoute['parameters']))


### PR DESCRIPTION
My API has some query parameters that are needed to use it. This pull request adds a new command line param such that you can pass parameters just like you can add bindings. These parameters are added to each route when it has the new @queryParameters annotation.

So in my example I can do this:
`php artisan api:generate --routePrefix='api/*' --parameters='startDate,2017-01-01|endDate,2017-01-07'`

And the route that has this will receive these two query parameters:
`/** * @queryParameters [startDate,endDate] */`

