### PR TITLE
Feature Added support for multiple prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ To generate your API documentation, use the `api:generate` artisan command.
 
 ```sh
 $ php artisan api:generate --routePrefix="api/v1/*"
-```
 
-After 28ff33be15424ff5a5b819dbe88b34468d1752b2 this commit, it supports passing generation of multiple prefixes by spearating each prefix with comma.
+```
+You can pass in multiple prefixes by spearating each prefix with comma.
 
 ```sh
 $ php artisan api:generate --routePrefix="api/v1/*,api/public/*"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ To generate your API documentation, use the `api:generate` artisan command.
 $ php artisan api:generate --routePrefix="api/v1/*"
 ```
 
+After 28ff33be15424ff5a5b819dbe88b34468d1752b2 this commit, it supports passing generation of multiple prefixes by spearating each prefix with comma.
+
+```sh
+$ php artisan api:generate --routePrefix="api/v1/*,api/public/*"
+```
+It will generate documentation for all of the routes whose prefixes are `api/v1/` and `api/public/`
+
+
 This command will scan your applications routes for the URIs matching `api/v1/*` and will parse these controller methods and form requests. For example:
 
 ```php
@@ -53,7 +61,7 @@ Route::group(array('prefix' => 'api/v1', 'middleware' => []), function () {
 Option | Description
 --------- | -------
 `output` | The output path used for the generated documentation. Default: `public/docs`
-`routePrefix` | The route prefix to use for generation - `*` can be used as a wildcard
+`routePrefix` | The route prefix to use for generation - `*` can be used as a wildcard 
 `routes` | The route names to use for generation - Required if no routePrefix is provided
 `middleware` | The middlewares to use for generation
 `noResponseCalls` | Disable API response calls

--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -81,7 +81,7 @@ class GenerateDocumentation extends Command
 
         $routePrefixes = explode(",", $routePrefix);
 
-        $parsedRoutes   =   [];
+        $parsedRoutes =   [];
 
         if ($this->option('router') === 'laravel') {
             foreach ($routePrefixes as $routePrefix) {

--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -81,7 +81,7 @@ class GenerateDocumentation extends Command
 
         $routePrefixes = explode(",", $routePrefix);
 
-        $parsedRoutes =   [];
+        $parsedRoutes = [];
 
         if ($this->option('router') === 'laravel') {
             foreach ($routePrefixes as $routePrefix) {

--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -79,10 +79,18 @@ class GenerateDocumentation extends Command
 
         $generator->prepareMiddleware($this->option('useMiddlewares'));
 
+        $routePrefixes = explode(",", $routePrefix);
+
+        $parsedRoutes   =   [];
+
         if ($this->option('router') === 'laravel') {
-            $parsedRoutes = $this->processLaravelRoutes($generator, $allowedRoutes, $routePrefix, $middleware);
+            foreach ($routePrefixes as $routePrefix) {
+                $parsedRoutes += $this->processLaravelRoutes($generator, $allowedRoutes, $routePrefix, $middleware);
+            }
         } else {
-            $parsedRoutes = $this->processDingoRoutes($generator, $allowedRoutes, $routePrefix, $middleware);
+            foreach ($routePrefixes as $routePrefix) {
+                $parsedRoutes += $this->processDingoRoutes($generator, $allowedRoutes, $routePrefix, $middleware);
+            }
         }
         $parsedRoutes = collect($parsedRoutes)->groupBy('resource')->sort(function ($a, $b) {
             return strcmp($a->first()['resource'], $b->first()['resource']);

--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -79,7 +79,7 @@ class GenerateDocumentation extends Command
 
         $generator->prepareMiddleware($this->option('useMiddlewares'));
 
-        $routePrefixes = explode(",", $routePrefix);
+        $routePrefixes = explode(',', $routePrefix);
 
         $parsedRoutes = [];
 


### PR DESCRIPTION
Now we can generate documentation for multiple route prefixes like below
`$ php artisan api:generate --routePrefix="api/v1/*,api/public/*"`
i.e. separated by comma and it is backward compatible.
So, It will generate documentation for all of the routes whose prefixes are `api/v1/` and `api/public/`
Now we have the ability to generate for multiple prefixes

@mpociot I hope it looks good