### PR TITLE
allow description for custom validation rules

### DIFF
--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -433,6 +433,12 @@ abstract class AbstractGenerator
                 $attributeData['value'] = $faker->ipv4;
                 $attributeData['type'] = $rule;
                 break;
+            default:
+                $unknownRuleDescription = Description::parse($rule)->getDescription();
+                if ($unknownRuleDescription) {
+                    $attributeData['description'][] = $unknownRuleDescription;
+                }
+                break;
         }
 
         if ($attributeData['value'] === '') {


### PR DESCRIPTION
When using custom validation rules, currently there is now way to show some description.
With adding this change, its possible to add the rules to the rule translation file and they will be shown in the description column.