### PR TITLE
Support custom validator method on laravel FormRequest

### DIFF
--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -11,6 +11,7 @@ use Mpociot\Reflection\DocBlock\Tag;
 use Illuminate\Support\Facades\Request;
 use League\Fractal\Resource\Collection;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 
 class LaravelGenerator extends AbstractGenerator
 {
@@ -266,7 +267,8 @@ class LaravelGenerator extends AbstractGenerator
                     $parameterReflection->request->add($bindings);
 
                     if (method_exists($parameterReflection, 'validator')) {
-                        return app()->call([$parameterReflection, 'validator'])
+                        $factory = app()->make(ValidationFactory::class);
+                        return app()->call([$parameterReflection, 'validator'], [$factory])
                             ->getRules();
                     } else {
                         return app()->call([$parameterReflection, 'rules']);

--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -268,6 +268,7 @@ class LaravelGenerator extends AbstractGenerator
 
                     if (method_exists($parameterReflection, 'validator')) {
                         $factory = app()->make(ValidationFactory::class);
+
                         return app()->call([$parameterReflection, 'validator'], [$factory])
                             ->getRules();
                     } else {

--- a/tests/ApiDocGeneratorTest.php
+++ b/tests/ApiDocGeneratorTest.php
@@ -337,6 +337,16 @@ class ApiDocGeneratorTest extends TestCase
         }
     }
 
+    public function testCustomFormRequestValidatorIsSupported()
+    {
+        RouteFacade::post('/post', TestController::class.'@customFormRequestValidator');
+        $route = new Route(['POST'], '/post', ['uses' => TestController::class.'@customFormRequestValidator']);
+        $parsed = $this->generator->processRoute($route);
+        $parameters = $parsed['parameters'];
+
+        $this->assertNotEmpty($parameters);
+    }
+
     public function testCanParseResponseTag()
     {
         RouteFacade::post('/responseTag', TestController::class.'@responseTag');

--- a/tests/Fixtures/CustomValidatorRequest.php
+++ b/tests/Fixtures/CustomValidatorRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mpociot\ApiDoc\Tests\Fixtures;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CustomValidatorRequest extends FormRequest
+{
+    /**
+     * Validate the input.
+     *
+     * @param \Illuminate\Validation\Factory $factory
+     *
+     * @return \Illuminate\Validation\Validator
+     */
+    public function validator($factory)
+    {
+        return $factory->make(
+            $this->validationData(), $this->container->call([$this, 'foo']),
+            $this->messages(), $this->attributes()
+        );
+    }
+
+    public function foo()
+    {
+        return [
+            'required' => 'required',
+        ];
+    }
+}

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -27,6 +27,11 @@ class TestController extends Controller
         return '';
     }
 
+    public function customFormRequestValidator(CustomValidatorRequest $request)
+    {
+        return '';
+    }
+
     public function addRouteBindingsToRequestClass(DynamicRequest $request)
     {
         return '';


### PR DESCRIPTION
When using custom validator method on a FormRequest laravel passes a validator factory.

This pull request updates the generator to pass the factory too to avoid errors when using this factory.