### PR TITLE
added composer section `extra` for package discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Require this package with composer using the following command:
 ```sh
 $ composer require mpociot/laravel-apidoc-generator
 ```
-Go to your `config/app.php` and add the service provider:
+Using Laravel < 5.5? Go to your `config/app.php` and add the service provider:
 
 ```php
 Mpociot\ApiDoc\ApiDocGeneratorServiceProvider::class,

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "mpociot/laravel-apidoc-generator",
+    "version": "2.0.1",
     "license": "MIT",
     "description": "Generate beautiful API documentation from your Laravel application",
     "keywords": [
@@ -36,6 +37,13 @@
     "autoload-dev": {
         "psr-4": {
             "Mpociot\\ApiDoc\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Mpociot\\ApiDoc\\ApiDocGeneratorServiceProvider"
+            ]
         }
     }
 }


### PR DESCRIPTION
New feature in Laravel 5.5 that allows for automatic package discovery.

Reduces the steps that need to be taken in order to install the package.

Tested by adding this fork as a repository in a projects composer.json and install laravel-apidoc-generator as a dependency.