### PR TITLE
[BUGFIXES] Header containing ":" + invalid "showresponse" condition

### DIFF
--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -112,9 +112,11 @@ abstract class AbstractGenerator
 
         // Split headers into key - value pairs
         $headers = collect($headers)->map(function ($value) {
-            $split = explode(':', $value);
+            $split = explode(':', $value); // explode to get key + values
+            $key   = array_shift($split); // extract the key and keep the values in the array
+            $value = implode(':', $split); // implode values into string again
 
-            return [trim($split[0]) => trim($split[1])];
+            return [trim($key) => trim($value)];
         })->collapse()->toArray();
 
         //Changes url with parameters like /users/{user} to /users/1

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -113,7 +113,7 @@ abstract class AbstractGenerator
         // Split headers into key - value pairs
         $headers = collect($headers)->map(function ($value) {
             $split = explode(':', $value); // explode to get key + values
-            $key   = array_shift($split); // extract the key and keep the values in the array
+            $key = array_shift($split); // extract the key and keep the values in the array
             $value = implode(':', $split); // implode values into string again
 
             return [trim($key) => trim($value)];

--- a/src/resources/views/partials/route.blade.php
+++ b/src/resources/views/partials/route.blade.php
@@ -38,7 +38,7 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-@if(in_array('GET',$parsedRoute['methods']) || isset($parsedRoute['showresponse']) && $parsedRoute['showresponse'])
+@if(in_array('GET',$parsedRoute['methods']) || (isset($parsedRoute['showresponse']) && $parsedRoute['showresponse']))
 > Example response:
 
 ```json


### PR DESCRIPTION
## Header with `:`
### Description
When you need an header value to contain ":", extracted value is incorrect.
### Example
when doing `php artisan api:generate --header='Authorization: Bearer:XXX:yyy:zzz`
your `Authorization` header value will be `Bearer` instead of `Bearer:XXX:yyy:zzz`

## `showresponse` Condition
### Description
Missing parenthesis in `showresponse` condition display (consecutive usage of `AND`/`OR` with no parenthesis...) 
### Example
create any transformer for any non-GET route (POST, PUT, etc.)
the response will never be shown in the interface
