### PR TITLE
Memory leak, too many connections to SQL

### DIFF
--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -140,11 +140,6 @@ class LaravelGenerator extends AbstractGenerator
 
         $kernel->terminate($request, $response);
 
-        if (file_exists($file = App::bootstrapPath().'/app.php')) {
-            $app = require $file;
-            $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
-        }
-
         return $response;
     }
 


### PR DESCRIPTION
In a bigger application, this cause fatal error Too many SQL connections opened. Also slows down api generation by alot and doesn't seem to do anything after the application is bootstrapped.