### PR TITLE
remove --actAsUserId parameter conversion to int

### DIFF
--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -222,12 +222,12 @@ class GenerateDocumentation extends Command
         if (! empty($actAs)) {
             if (version_compare($this->laravel->version(), '5.2.0', '<')) {
                 $userModel = config('auth.model');
-                $user = $userModel::find((int) $actAs);
+                $user = $userModel::find($actAs);
                 $this->laravel['auth']->setUser($user);
             } else {
                 $provider = $this->option('authProvider');
                 $userModel = config("auth.providers.$provider.model");
-                $user = $userModel::find((int) $actAs);
+                $user = $userModel::find($actAs);
                 $this->laravel['auth']->guard($this->option('authGuard'))->setUser($user);
             }
         }


### PR DESCRIPTION
Removes the obligation to transform the parameter into an integer. The original static method [accepts an ID of type mixed](https://laravel.com/api/5.5/Illuminate/Database/Eloquent/Collection.html#method_find).

That way, applications that keep their identifier using another data type, such as the UUID equivalent, can use this package.