### PR TITLE
allow formatting and aside tags

### DIFF
--- a/src/resources/views/documentarian.blade.php
+++ b/src/resources/views/documentarian.blade.php
@@ -7,7 +7,7 @@
 
 @foreach($parsedRoutes as $group => $routes)
 @if($group)
-#{{$group}}
+#{!! $group !!}
 @endif
 @foreach($routes as $parsedRoute)
 @if($writeCompareFile === true)


### PR DESCRIPTION
The group description was escaping everything by default meaning that the aside tag (which is quite useful) can't be used in a group header. This addresses that by no longer escaping the content, as is consistent with the rest of the library.