### PR TITLE
Add lumen support. Set minimum laravel/lumen version to ^5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "fzaninotto/faker": "~1.0",
         "mpociot/documentarian": "^0.2.0",
         "mpociot/reflection-docblock": "^1.0",
-        "ramsey/uuid": "^3.0",
-        "illuminate/http": "^5.5"
+        "ramsey/uuid": "^3.0"
     },
     "require-dev": {
         "orchestra/testbench": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.0",
         "fzaninotto/faker": "~1.0",
-        "laravel/framework": "~5.4",
         "mpociot/documentarian": "^0.2.0",
         "mpociot/reflection-docblock": "^1.0",
-        "ramsey/uuid": "^3.0"
+        "ramsey/uuid": "^3.0",
+        "illuminate/http": "^5.5"
     },
     "require-dev": {
         "orchestra/testbench": "~3.0",
         "phpunit/phpunit": "~4.0 || ~5.0",
-        "dingo/api": "1.0.*@dev",
+        "dingo/api": "^v2.0.0-alpha1",
         "mockery/mockery": "^0.9.5"
     },
     "autoload": {

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -6,10 +6,10 @@ use Faker\Factory;
 use ReflectionClass;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Http\Request;
 use Mpociot\Reflection\DocBlock;
 use Mpociot\Reflection\DocBlock\Tag;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Foundation\Http\FormRequest;
 use Mpociot\ApiDoc\Parsers\RuleDescriptionParser as Description;
 
 abstract class AbstractGenerator
@@ -201,7 +201,10 @@ abstract class AbstractGenerator
             if (! is_null($parameterType) && class_exists($parameterType->name)) {
                 $className = $parameterType->name;
 
-                if (is_subclass_of($className, FormRequest::class)) {
+                if (is_subclass_of($className, Request::class)
+                    && method_exists($className, 'authorize')
+                    &&  method_exists($className, 'rules')
+                ) {
                     $parameterReflection = new $className;
                     // Add route parameter bindings
                     $parameterReflection->query->add($bindings);

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -203,7 +203,7 @@ abstract class AbstractGenerator
 
                 if (is_subclass_of($className, Request::class)
                     && method_exists($className, 'authorize')
-                    &&  method_exists($className, 'rules')
+                    && method_exists($className, 'rules')
                 ) {
                     $parameterReflection = new $className;
                     // Add route parameter bindings

--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -4,13 +4,13 @@ namespace Mpociot\ApiDoc\Generators;
 
 use ReflectionClass;
 use League\Fractal\Manager;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use League\Fractal\Resource\Item;
 use Illuminate\Support\Facades\App;
 use Mpociot\Reflection\DocBlock\Tag;
-use Illuminate\Support\Facades\Request;
 use League\Fractal\Resource\Collection;
-use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Request as RequestFacade;
 
 class LaravelGenerator extends AbstractGenerator
 {
@@ -130,7 +130,7 @@ class LaravelGenerator extends AbstractGenerator
             'Accept' => 'application/json',
         ])->merge($server)->toArray();
 
-        $request = Request::create(
+        $request = RequestFacade::create(
             $uri, $method, $parameters,
             $cookies, $files, $this->transformHeadersToServerVars($server), $content
         );
@@ -258,7 +258,10 @@ class LaravelGenerator extends AbstractGenerator
             if (! is_null($parameterType) && class_exists($parameterType->name)) {
                 $className = $parameterType->name;
 
-                if (is_subclass_of($className, FormRequest::class)) {
+                if (is_subclass_of($className, Request::class)
+                    && method_exists($className, 'authorize')
+                    && method_exists($className, 'rules')
+                ) {
                     $parameterReflection = new $className;
                     $parameterReflection->setContainer(app());
                     // Add route parameter bindings

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -6,6 +6,11 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class TestRequest extends FormRequest
 {
+    public function authorize()
+    {
+        return true;
+    }
+
     public function rules()
     {
         return [

--- a/tests/Fixtures/resource_index.md
+++ b/tests/Fixtures/resource_index.md
@@ -13,10 +13,14 @@ toc_footers:
 - <a href='http://github.com/mpociot/documentarian'>Documentation Powered by Documentarian</a>
 ---
 <!-- START_INFO -->
+
+
 # Info
 
 Welcome to the generated API reference.
 [Get Postman Collection](http://localhost/docs/collection.json)
+
+
 
 <!-- END_INFO -->
 

--- a/tests/Fixtures/resource_index.md
+++ b/tests/Fixtures/resource_index.md
@@ -13,14 +13,10 @@ toc_footers:
 - <a href='http://github.com/mpociot/documentarian'>Documentation Powered by Documentarian</a>
 ---
 <!-- START_INFO -->
-
-
 # Info
 
 Welcome to the generated API reference.
 [Get Postman Collection](http://localhost/docs/collection.json)
-
-
 
 <!-- END_INFO -->
 

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -110,7 +110,7 @@ class GenerateDocumentationTest extends TestCase
         ]);
         $generatedMarkdown = file_get_contents(__DIR__.'/../public/docs/source/index.md');
         $fixtureMarkdown = file_get_contents(__DIR__.'/Fixtures/resource_index.md');
-        $this->assertSame($generatedMarkdown, $fixtureMarkdown);
+        $this->assertSame($fixtureMarkdown, $generatedMarkdown);
     }
 
     public function testGeneratedMarkdownFileIsCorrect()


### PR DESCRIPTION
A lot of people were asking for Lumen support and the only missing thing was the FormRequest class.

I think it's enough to assume the illuminate http request is a dependency and if the request has the "validate" and "rules" functions we can treat it as a FormRequest