### PR TITLE
Display the validation rules for array properties

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,5 +4,3 @@ enabled:
   - phpdoc_order
   - phpdoc_separation
   - unalign_double_arrow
-
-linting: true

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -100,9 +100,10 @@ abstract class AbstractGenerator
     }
 
     /**
-     * Format the validation rules as plain array
+     * Format the validation rules as plain array.
      *
      * @param array $rules
+     *
      * @return array
      */
     protected function simplifyRules($rules)


### PR DESCRIPTION
The code checks if there are rules of type *array* and sends array with one empty string for property, which makes the `Validator` to validate them, which results in beter documentation.