### PR TITLE
Print correct docs path in console

### DIFF
--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -197,7 +197,7 @@ class GenerateDocumentation extends Command
 
         $documentarian->generate($outputPath);
 
-        $this->info('Wrote HTML documentation to: '.$outputPath.'/public/index.html');
+        $this->info('Wrote HTML documentation to: '.$outputPath.'/index.html');
 
         if ($this->option('noPostmanCollection') !== true) {
             $this->info('Generating Postman collection');

--- a/src/Mpociot/ApiDoc/Commands/UpdateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/UpdateDocumentation.php
@@ -53,6 +53,6 @@ class UpdateDocumentation extends Command
 
         $documentarian->generate($outputPath);
 
-        $this->info('Wrote HTML documentation to: '.$outputPath.'/public/index.html');
+        $this->info('Wrote HTML documentation to: '.$outputPath.'/index.html');
     }
 }

--- a/src/resources/views/partials/route.blade.php
+++ b/src/resources/views/partials/route.blade.php
@@ -10,7 +10,7 @@
 > Example request:
 
 ```bash
-curl -X {{$parsedRoute['methods'][0]}} "{{config('app.docs_url') ?: config('app.url')}}/{{$parsedRoute['uri']}}" \
+curl -X {{$parsedRoute['methods'][0]}} "{{ trim(config('app.docs_url') ?: config('app.url'), '/')}}/{{ ltrim($parsedRoute['uri'], '/') }}" \
 -H "Accept: application/json"@if(count($parsedRoute['parameters'])) \
 @foreach($parsedRoute['parameters'] as $attribute => $parameter)
     -d "{{$attribute}}"="{{$parameter['value']}}" \
@@ -23,7 +23,7 @@ curl -X {{$parsedRoute['methods'][0]}} "{{config('app.docs_url') ?: config('app.
 var settings = {
     "async": true,
     "crossDomain": true,
-    "url": "{{config('app.docs_url') ?: config('app.url')}}/{{$parsedRoute['uri']}}",
+    "url": "{{ rtrim(config('app.docs_url') ?: config('app.url'), '/') }}/{{ ltrim($parsedRoute['uri'], '/') }}",
     "method": "{{$parsedRoute['methods'][0]}}",
     @if(count($parsedRoute['parameters']))
 "data": {!! str_replace('    ','        ',json_encode(array_combine(array_keys($parsedRoute['parameters']), array_map(function($param){ return $param['value']; },$parsedRoute['parameters'])), JSON_PRETTY_PRINT)) !!},


### PR DESCRIPTION
This PR removes the extra `public` in the path that was printed