### PR TITLE
Fix before/after date validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). If you make a pull request to this project, please update this changelog.
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Parse `@response` tags regardless of HTTP method
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ If the project maintainer has any additional requirements, you will find them li
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 
-- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date. Add your changes to the `CHANGELOG.md` under the "Unreleased" section.
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
 
 - **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
 

--- a/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/AbstractGenerator.php
@@ -152,7 +152,7 @@ abstract class AbstractGenerator
                 'description' => [],
             ];
             foreach ($ruleset as $rule) {
-                $this->parseRule($rule, $attribute, $attributeData, $routeData['id']);
+                $this->parseRule($rule, $attribute, $attributeData, $routeData['id'], $routeData);
             }
             $routeData['parameters'][$attribute] = $attributeData;
         }
@@ -356,7 +356,7 @@ abstract class AbstractGenerator
      *
      * @return void
      */
-    protected function parseRule($rule, $ruleName, &$attributeData, $seed)
+    protected function parseRule($rule, $ruleName, &$attributeData, $seed, $routeData)
     {
         $faker = Factory::create();
         $faker->seed(crc32($seed));
@@ -376,8 +376,17 @@ abstract class AbstractGenerator
                 break;
             case 'after':
                 $attributeData['type'] = 'date';
-                $attributeData['description'][] = Description::parse($rule)->with(date(DATE_RFC850, strtotime($parameters[0])))->getDescription();
-                $attributeData['value'] = date(DATE_RFC850, strtotime('+1 day', strtotime($parameters[0])));
+                $format = isset($attributeData['format']) ? $attributeData['format'] : DATE_RFC850;
+
+                if (strtotime($parameters[0]) === false) {
+                    // the `after` date refers to another parameter in the request
+                    $paramName = $parameters[0];
+                    $attributeData['description'][] = Description::parse($rule)->with($paramName)->getDescription();
+                    $attributeData['value'] = date($format, strtotime('+1 day', strtotime($routeData['parameters'][$paramName]['value'])));
+                } else {
+                    $attributeData['description'][] = Description::parse($rule)->with(date($format, strtotime($parameters[0])))->getDescription();
+                    $attributeData['value'] = date($format, strtotime('+1 day', strtotime($parameters[0])));
+                }
                 break;
             case 'alpha':
                 $attributeData['description'][] = Description::parse($rule)->getDescription();
@@ -418,13 +427,23 @@ abstract class AbstractGenerator
                 break;
             case 'before':
                 $attributeData['type'] = 'date';
-                $attributeData['description'][] = Description::parse($rule)->with(date(DATE_RFC850, strtotime($parameters[0])))->getDescription();
-                $attributeData['value'] = date(DATE_RFC850, strtotime('-1 day', strtotime($parameters[0])));
+                $format = isset($attributeData['format']) ? $attributeData['format'] : DATE_RFC850;
+
+                if (strtotime($parameters[0]) === false) {
+                    // the `before` date refers to another parameter in the request
+                    $paramName = $parameters[0];
+                    $attributeData['description'][] = Description::parse($rule)->with($paramName)->getDescription();
+                    $attributeData['value'] = date($format, strtotime('-1 day', strtotime($routeData['parameters'][$paramName]['value'])));
+                } else {
+                    $attributeData['description'][] = Description::parse($rule)->with(date($format, strtotime($parameters[0])))->getDescription();
+                    $attributeData['value'] = date($format, strtotime('-1 day', strtotime($parameters[0])));
+                }
                 break;
             case 'date_format':
                 $attributeData['type'] = 'date';
                 $attributeData['description'][] = Description::parse($rule)->with($parameters)->getDescription();
-                $attributeData['value'] = date($parameters[0]);
+                $attributeData['format'] = $parameters[0];
+                $attributeData['value'] = date($attributeData['format']);
                 break;
             case 'different':
                 $attributeData['description'][] = Description::parse($rule)->with($parameters)->getDescription();


### PR DESCRIPTION
The package now parses the rule correctly when parameter passed to the `before`/`after` rule references another parameter in the request.