### PR TITLE
Rename commands namespace from api to apidoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ Mpociot\ApiDoc\ApiDocGeneratorServiceProvider::class,
 
 ## Usage
 
-To generate your API documentation, use the `api:generate` artisan command.
+To generate your API documentation, use the `apidoc:generate` artisan command.
 
 ```sh
-$ php artisan api:generate --routePrefix="api/v1/*"
+$ php artisan apidoc:generate --routePrefix="api/v1/*"
 
 ```
 You can pass in multiple prefixes by spearating each prefix with comma.
 
 ```sh
-$ php artisan api:generate --routePrefix="api/v1/*,api/public/*"
+$ php artisan apidoc:generate --routePrefix="api/v1/*,api/public/*"
 ```
 It will generate documentation for all of the routes whose prefixes are `api/v1/` and `api/public/`
 
@@ -201,13 +201,13 @@ If your API route accepts a `GET` method, this package tries to call the API rou
 If your API needs an authenticated user, you can use the `actAsUserId` option to specify a user ID that will be used for making these API calls:
 
 ```sh
-$ php artisan api:generate --routePrefix="api/*" --actAsUserId=1
+$ php artisan apidoc:generate --routePrefix="api/*" --actAsUserId=1
 ```
 
 If you don't want to automatically perform API response calls, use the `noResponseCalls` option.
 
 ```sh
-$ php artisan api:generate --routePrefix="api/*" --noResponseCalls
+$ php artisan apidoc:generate --routePrefix="api/*" --noResponseCalls
 ```
 
 > Note: The example API responses work best with seeded data.
@@ -235,10 +235,10 @@ APP_URL=http://yourapp.app
 If you want to modify the content of your generated documentation, go ahead and edit the generated `index.md` file.
 The default location of this file is: `public/docs/source/index.md`.
  
-After editing the markdown file, use the `api:update` command to rebuild your documentation as a static HTML file.
+After editing the markdown file, use the `apidoc:update` command to rebuild your documentation as a static HTML file.
 
 ```sh
-$ php artisan api:update
+$ php artisan apidoc:update
 ```
 
 As an optional parameter, you can use `--location` to tell the update command where your documentation can be found.

--- a/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/GenerateDocumentation.php
@@ -21,7 +21,7 @@ class GenerateDocumentation extends Command
      *
      * @var string
      */
-    protected $signature = 'api:generate
+    protected $signature = 'apidoc:generate
                             {--output=public/docs : The output path for the generated documentation}
                             {--routeDomain= : The route domain (or domains) to use for generation}
                             {--routePrefix= : The route prefix (or prefixes) to use for generation}

--- a/src/Mpociot/ApiDoc/Commands/UpdateDocumentation.php
+++ b/src/Mpociot/ApiDoc/Commands/UpdateDocumentation.php
@@ -12,7 +12,7 @@ class UpdateDocumentation extends Command
      *
      * @var string
      */
-    protected $signature = 'api:update 
+    protected $signature = 'apidoc:update 
                             {--location=public/docs : The documentation location}
     ';
 

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -64,7 +64,7 @@ class GenerateDocumentationTest extends TestCase
 
     public function testConsoleCommandNeedsPrefixesOrDomainsOrRoutes()
     {
-        $output = $this->artisan('api:generate');
+        $output = $this->artisan('apidoc:generate');
         $this->assertEquals('You must provide either a route prefix, a route domain, a route or a middleware to generate the documentation.'.PHP_EOL, $output);
     }
 
@@ -75,7 +75,7 @@ class GenerateDocumentationTest extends TestCase
         });
         RouteFacade::get('/api/test', TestController::class.'@parseMethodDescription');
 
-        $output = $this->artisan('api:generate', [
+        $output = $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
         $this->assertContains('Skipping route: [GET] api/closure', $output);
@@ -95,7 +95,7 @@ class GenerateDocumentationTest extends TestCase
             });
             $api->get('/test', DingoTestController::class.'@parseMethodDescription');
 
-            $output = $this->artisan('api:generate', [
+            $output = $this->artisan('apidoc:generate', [
                 '--router' => 'dingo',
                 '--routePrefix' => 'v1',
             ]);
@@ -109,7 +109,7 @@ class GenerateDocumentationTest extends TestCase
         RouteFacade::get('/api/skip', TestController::class.'@skip');
         RouteFacade::get('/api/test', TestController::class.'@parseMethodDescription');
 
-        $output = $this->artisan('api:generate', [
+        $output = $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
         $this->assertContains('Skipping route: [GET] api/skip', $output);
@@ -119,7 +119,7 @@ class GenerateDocumentationTest extends TestCase
     public function testCanParseResourceRoutes()
     {
         RouteFacade::resource('/api/user', TestResourceController::class);
-        $output = $this->artisan('api:generate', [
+        $output = $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
         $fixtureMarkdown = __DIR__.'/Fixtures/resource_index.md';
@@ -134,7 +134,7 @@ class GenerateDocumentationTest extends TestCase
                 'index', 'create',
             ],
         ]);
-        $output = $this->artisan('api:generate', [
+        $output = $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
         $fixtureMarkdown = __DIR__.'/Fixtures/partial_resource_index.md';
@@ -146,7 +146,7 @@ class GenerateDocumentationTest extends TestCase
                 'index', 'create',
             ],
         ]);
-        $output = $this->artisan('api:generate', [
+        $output = $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
         $fixtureMarkdown = __DIR__.'/Fixtures/partial_resource_index.md';
@@ -159,7 +159,7 @@ class GenerateDocumentationTest extends TestCase
         RouteFacade::get('/api/test', TestController::class.'@parseMethodDescription');
         RouteFacade::get('/api/fetch', TestController::class.'@fetchRouteResponse');
 
-        $output = $this->artisan('api:generate', [
+        $output = $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
 
@@ -175,7 +175,7 @@ class GenerateDocumentationTest extends TestCase
         RouteFacade::get('/api/test', TestController::class.'@parseMethodDescription');
         RouteFacade::get('/api/fetch', TestController::class.'@fetchRouteResponse');
 
-        $this->artisan('api:generate', [
+        $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
 
@@ -184,7 +184,7 @@ class GenerateDocumentationTest extends TestCase
         copy($prependMarkdown, __DIR__.'/../public/docs/source/prepend.md');
         copy($appendMarkdown, __DIR__.'/../public/docs/source/append.md');
 
-        $this->artisan('api:generate', [
+        $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
 
@@ -197,7 +197,7 @@ class GenerateDocumentationTest extends TestCase
     {
         RouteFacade::get('/api/test/{foo}', TestController::class.'@addRouteBindingsToRequestClass');
 
-        $this->artisan('api:generate', [
+        $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
             '--bindings' => 'foo,bar',
         ]);
@@ -212,7 +212,7 @@ class GenerateDocumentationTest extends TestCase
         RouteFacade::get('/api/test', TestController::class.'@parseMethodDescription');
         RouteFacade::post('/api/fetch', TestController::class.'@fetchRouteResponse');
 
-        $output = $this->artisan('api:generate', [
+        $output = $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
 
@@ -227,7 +227,7 @@ class GenerateDocumentationTest extends TestCase
     {
         RouteFacade::get('/api/headers', TestController::class.'@checkCustomHeaders');
 
-        $output = $this->artisan('api:generate', [
+        $output = $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
             '--header' => [
                 'Authorization: customAuthToken',
@@ -248,7 +248,7 @@ class GenerateDocumentationTest extends TestCase
     {
         RouteFacade::get('/api/utf8', TestController::class.'@utf8');
 
-        $output = $this->artisan('api:generate', [
+        $output = $this->artisan('apidoc:generate', [
             '--routePrefix' => 'api/*',
         ]);
 


### PR DESCRIPTION
Resolves https://github.com/mpociot/laravel-apidoc-generator/issues/346.