### PR TITLE
Fixed APP_URL in .env didn't work for postman

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "vitta/laravel-apidoc-generator",
+    "name": "mpociot/laravel-apidoc-generator",
     "license": "MIT",
     "description": "Generate beautiful API documentation from your Laravel application",
     "keywords": [
@@ -7,7 +7,7 @@
         "Documentation",
         "Laravel"
     ],
-    "homepage": "https://github.com/Joker-1991/laravel-apidoc-generator.git",
+    "homepage": "http://github.com/mpociot/laravel-apidoc-generator",
     "authors": [
         {
             "name": "Marcel Pociot",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "Documentation",
         "Laravel"
     ],
-    "homepage": "http://github.com/mpociot/laravel-apidoc-generator",
+    "homepage": "https://github.com/Joker-1991/laravel-apidoc-generator.git",
     "authors": [
         {
             "name": "Marcel Pociot",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mpociot/laravel-apidoc-generator",
+    "name": "vitta/laravel-apidoc-generator",
     "license": "MIT",
     "description": "Generate beautiful API documentation from your Laravel application",
     "keywords": [
@@ -48,6 +48,6 @@
             "providers": [
                 "Mpociot\\ApiDoc\\ApiDocGeneratorServiceProvider"
             ]
-       }
+        }
     }
 }

--- a/src/Generators/LaravelGenerator.php
+++ b/src/Generators/LaravelGenerator.php
@@ -79,7 +79,10 @@ class LaravelGenerator extends AbstractGenerator
         $response = $kernel->handle($request);
 
         $kernel->terminate($request, $response);
-
+        if (file_exists($file = App::bootstrapPath().'/app.php')) {
+            $app = require $file;
+            $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        }
         return $response;
     }
 }


### PR DESCRIPTION
I saw that bug on https://github.com/mpociot/laravel-apidoc-generator/issues/65
And it had already fixed by https://github.com/mpociot/laravel-apidoc-generator/commit/9bbc18b769b53e888709d1da204edec56ba59748
But now I meet the question again, and I find the codes disappeared 