### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ composer require mpociot/laravel-apidoc-generator
 Publish the config file by running:
 
 ```bash
-php artisan vendor:publish --provider=Mpociot\ApiDoc\ApiDocGeneratorServiceProvider --tag=config
+php artisan vendor:publish --provider="Mpociot\ApiDoc\ApiDocGeneratorServiceProvider" --tag=config
 ```
 This will create an `apidoc.php` file in your `config` folder.
 


### PR DESCRIPTION
In my enviorment needed the double quotes in order for the "php artisan vendor:publish" command to work.