### PR TITLE
Replace config_path() by generic code

### DIFF
--- a/src/ApiDocGeneratorServiceProvider.php
+++ b/src/ApiDocGeneratorServiceProvider.php
@@ -22,7 +22,7 @@ class ApiDocGeneratorServiceProvider extends ServiceProvider
         ], 'views');
 
         $this->publishes([
-            __DIR__.'/../config/apidoc.php' => config_path('apidoc.php'),
+            __DIR__.'/../config/apidoc.php' => app()->basePath().'/config/apidoc.php',
         ], 'config');
 
         $this->mergeConfigFrom(__DIR__.'/../config/apidoc.php', 'apidoc');


### PR DESCRIPTION
`config_path()` does not exists in "Vanilla" lumen.
It may be defined by some plugins but by default it does not exists.

Fixes: 
![screen shot 2018-10-31 at 3 49 59 pm](https://user-images.githubusercontent.com/2412909/47814655-a9ac4280-dd24-11e8-816e-dcb0201c4f3e.png)
