### PR TITLE
Update GenerateDocumentation.php

### DIFF
--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -45,7 +45,7 @@ class GenerateDocumentation extends Command
      */
     public function handle()
     {
-        $usingDingoRouter = config('apidoc.router') == 'dingo';
+        $usingDingoRouter = strtolower(config('apidoc.router')) == 'dingo';
         if ($usingDingoRouter) {
             $routes = $this->routeMatcher->getDingoRoutesToBeDocumented(config('apidoc.routes'));
         } else {


### PR DESCRIPTION
Ensure the router is properly read notwithstanding the case in which **Dingo** or **Laravel** is typed.

The is more so important seeing that the documentation gives the options as **Dingo** or **Laravel** but the command reads only **dingo**.