### PR TITLE
Use a file payload as response

### DIFF
--- a/src/Tools/ResponseResolver.php
+++ b/src/Tools/ResponseResolver.php
@@ -3,6 +3,7 @@
 namespace Mpociot\ApiDoc\Tools;
 
 use Illuminate\Routing\Route;
+use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseFileStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseTagStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseCallStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\TransformerTagsStrategy;
@@ -12,6 +13,7 @@ class ResponseResolver
     public static $strategies = [
         ResponseTagStrategy::class,
         TransformerTagsStrategy::class,
+        ResponseFileStrategy::class,
         ResponseCallStrategy::class,
     ];
 

--- a/src/Tools/ResponseResolver.php
+++ b/src/Tools/ResponseResolver.php
@@ -3,9 +3,9 @@
 namespace Mpociot\ApiDoc\Tools;
 
 use Illuminate\Routing\Route;
-use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseFileStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseTagStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseCallStrategy;
+use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseFileStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\TransformerTagsStrategy;
 
 class ResponseResolver

--- a/src/Tools/ResponseStrategies/ResponseFileStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseFileStrategy.php
@@ -24,15 +24,15 @@ class ResponseFileStrategy
      */
     protected function getFileResponse(array $tags)
     {
-        $responseTags = array_filter($tags, function ($tag) {
+        $responseFileTags = array_filter($tags, function ($tag) {
             return $tag instanceof Tag && strtolower($tag->getName()) == 'responsefile';
         });
-        if (empty($responseTags)) {
+        if (empty($responseFileTags)) {
             return;
         }
-        $responseTag = array_first($responseTags);
+        $responseFileTag = array_first($responseFileTags);
 
-        $json = json_decode(file_get_contents(storage_path($responseTag->getContent()), true), true);
+        $json = json_decode(file_get_contents(storage_path($responseFileTag->getContent()), true), true);
 
         return response()->json($json);
     }

--- a/src/Tools/ResponseStrategies/ResponseFileStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseFileStrategy.php
@@ -3,6 +3,7 @@
 namespace Mpociot\ApiDoc\Tools\ResponseStrategies;
 
 use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Storage;
 use Mpociot\Reflection\DocBlock\Tag;
 
 /**
@@ -32,7 +33,7 @@ class ResponseFileStrategy
         }
         $responseFileTag = array_first($responseFileTags);
 
-        $json = json_decode(file_get_contents(storage_path($responseFileTag->getContent()), true), true);
+        $json = json_decode(Storage::get($responseFileTag->getContent()), true);
 
         return response()->json($json);
     }

--- a/src/Tools/ResponseStrategies/ResponseFileStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseFileStrategy.php
@@ -3,8 +3,8 @@
 namespace Mpociot\ApiDoc\Tools\ResponseStrategies;
 
 use Illuminate\Routing\Route;
-use Illuminate\Support\Facades\Storage;
 use Mpociot\Reflection\DocBlock\Tag;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * Get a response from from a file in the docblock ( @responseFile ).

--- a/src/Tools/ResponseStrategies/ResponseFileStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseFileStrategy.php
@@ -4,7 +4,6 @@ namespace Mpociot\ApiDoc\Tools\ResponseStrategies;
 
 use Illuminate\Routing\Route;
 use Mpociot\Reflection\DocBlock\Tag;
-use Illuminate\Support\Facades\Storage;
 
 /**
  * Get a response from from a file in the docblock ( @responseFile ).
@@ -33,7 +32,7 @@ class ResponseFileStrategy
         }
         $responseFileTag = array_first($responseFileTags);
 
-        $json = json_decode(Storage::get($responseFileTag->getContent()), true);
+        $json = json_decode(file_get_contents(storage_path($responseFileTag->getContent()), true), true);
 
         return response()->json($json);
     }

--- a/src/Tools/ResponseStrategies/ResponseFileStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseFileStrategy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Mpociot\ApiDoc\Tools\ResponseStrategies;
+
+use Illuminate\Routing\Route;
+use Mpociot\Reflection\DocBlock\Tag;
+
+/**
+ * Get a response from from a file in the docblock ( @responseFile ).
+ */
+class ResponseFileStrategy
+{
+    public function __invoke(Route $route, array $tags, array $routeProps)
+    {
+        return $this->getFileResponse($tags);
+    }
+
+    /**
+     * Get the response from the file if available.
+     *
+     * @param array $tags
+     *
+     * @return mixed
+     */
+    protected function getFileResponse(array $tags)
+    {
+        $responseTags = array_filter($tags, function ($tag) {
+            return $tag instanceof Tag && strtolower($tag->getName()) == 'responsefile';
+        });
+        if (empty($responseTags)) {
+            return;
+        }
+        $responseTag = array_first($responseTags);
+
+        $json = json_decode(file_get_contents(storage_path($responseTag->getContent()), true), true);
+
+        return response()->json($json);
+    }
+}

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -165,7 +165,7 @@ class TestController extends Controller
     }
 
     /**
-     * @responseFile response_test.json
+     * @responseFile app/response_test.json
      */
     public function responseFileTag()
     {

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -165,7 +165,7 @@ class TestController extends Controller
     }
 
     /**
-     * @responseFile app/response_test.json
+     * @responseFile response_test.json
      */
     public function responseFileTag()
     {

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -163,4 +163,12 @@ class TestController extends Controller
     {
         return '';
     }
+
+    /**
+     * @responseFile /test.json
+     */
+    public function responseFileTag()
+    {
+        return '';
+    }
 }

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -165,7 +165,7 @@ class TestController extends Controller
     }
 
     /**
-     * @responseFile /test.json
+     * @responseFile response_test.json
      */
     public function responseFileTag()
     {

--- a/tests/Fixtures/response_test.json
+++ b/tests/Fixtures/response_test.json
@@ -1,0 +1,1 @@
+{"id":5,"name":"Jessica Jones","gender":"female"}

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -220,7 +220,7 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $this->artisan('apidoc:generate');
 
-        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'));
+        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../../public/docs/collection.json'));
         $generatedCollection->info->_postman_id = '';
         $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection.json'));
         $this->assertEquals($generatedCollection, $fixtureCollection);

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -220,7 +220,7 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $this->artisan('apidoc:generate');
 
-        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../../public/docs/collection.json'));
+        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'));
         $generatedCollection->info->_postman_id = '';
         $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection.json'));
         $this->assertEquals($generatedCollection, $fixtureCollection);

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -270,8 +270,9 @@ abstract class GeneratorTestCase extends TestCase
     public function can_parse_response_file_tag()
     {
         // copy file to storage
-        $fixtureFileJson = file_get_contents(__DIR__.'/../Fixtures/response_test.json');
-        Storage::put('response_test.json', $fixtureFileJson);
+        $filePath = __DIR__.'/../Fixtures/response_test.json';
+        $fixtureFileJson = file_get_contents($filePath);
+        copy ($filePath, storage_path('response_test.json'));
 
         $route = $this->createRoute('GET', '/responseFileTag', 'responseFileTag');
         $parsed = $this->generator->processRoute($route);
@@ -283,7 +284,7 @@ abstract class GeneratorTestCase extends TestCase
             $fixtureFileJson
         );
 
-        Storage::delete('response_test.json');
+        unlink(storage_path('response_test.json'));
     }
 
     /** @test */

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -272,7 +272,7 @@ abstract class GeneratorTestCase extends TestCase
         // copy file to storage
         $filePath = __DIR__.'/../Fixtures/response_test.json';
         $fixtureFileJson = file_get_contents($filePath);
-        copy ($filePath, storage_path('response_test.json'));
+        copy($filePath, storage_path('response_test.json'));
 
         $route = $this->createRoute('GET', '/responseFileTag', 'responseFileTag');
         $parsed = $this->generator->processRoute($route);

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -266,6 +266,32 @@ abstract class GeneratorTestCase extends TestCase
     }
 
     /** @test */
+    public function can_parse_response_file_tag()
+    {
+        // Create a file
+        $fp = fopen(storage_path('test.json'), 'w');
+        fwrite($fp, json_encode([
+            'id' => 5,
+            'name' => 'Jessica Jones',
+            'gender' => 'female'
+        ]));
+        fclose($fp);
+
+        $route = $this->createRoute('GET', '/responseFileTag', 'responseFileTag');
+        $parsed = $this->generator->processRoute($route);
+        $this->assertTrue(is_array($parsed));
+        $this->assertArrayHasKey('showresponse', $parsed);
+        $this->assertTrue($parsed['showresponse']);
+        $this->assertSame(
+            $parsed['response'],
+            '{"id":5,"name":"Jessica Jones","gender":"female"}'
+        );
+
+        unlink(storage_path('test.json'));
+    }
+
+
+    /** @test */
     public function uses_configured_settings_when_calling_route()
     {
         $route = $this->createRoute('PUT', '/echo/{id}', 'shouldFetchRouteResponseWithEchoedSettings', true);

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -2,12 +2,12 @@
 
 namespace Mpociot\ApiDoc\Tests\Unit;
 
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\TestCase;
 use Mpociot\ApiDoc\Tools\Generator;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
 use Mpociot\ApiDoc\ApiDocGeneratorServiceProvider;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 abstract class GeneratorTestCase extends TestCase
 {

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -4,10 +4,8 @@ namespace Mpociot\ApiDoc\Tests\Unit;
 
 use Orchestra\Testbench\TestCase;
 use Mpociot\ApiDoc\Tools\Generator;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
 use Mpociot\ApiDoc\ApiDocGeneratorServiceProvider;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 abstract class GeneratorTestCase extends TestCase
 {

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -273,7 +273,7 @@ abstract class GeneratorTestCase extends TestCase
         fwrite($fp, json_encode([
             'id' => 5,
             'name' => 'Jessica Jones',
-            'gender' => 'female'
+            'gender' => 'female',
         ]));
         fclose($fp);
 

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -289,36 +289,6 @@ abstract class GeneratorTestCase extends TestCase
     }
 
     /** @test */
-    public function can_parse_response_file_tag_using_another_filesystem_driver()
-    {
-        // Mocking
-        Storage::fake('s3');
-
-        // copy file to storage
-        $fixtureFileJson = file_get_contents(__DIR__.'/../Fixtures/response_test.json');
-        Storage::disk('s3')->put('response_test.json', $fixtureFileJson);
-
-        $route = $this->createRoute('GET', '/responseFileTag', 'responseFileTag');
-
-        // Exception, because the file is not on Local storage
-        $this->expectException(FileNotFoundException::class);
-        $this->generator->processRoute($route);
-
-        // Now, set the default config to s3
-        Config::set('filesystems.default', 's3');
-        $parsed = $this->generator->processRoute($route);
-        $this->assertTrue(is_array($parsed));
-        $this->assertArrayHasKey('showresponse', $parsed);
-        $this->assertTrue($parsed['showresponse']);
-        $this->assertSame(
-            $parsed['response'],
-            $fixtureFileJson
-        );
-
-        Storage::disk('s3')->delete('response_test.json');
-    }
-
-    /** @test */
     public function uses_configured_settings_when_calling_route()
     {
         $route = $this->createRoute('PUT', '/echo/{id}', 'shouldFetchRouteResponseWithEchoedSettings', true);

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -290,7 +290,6 @@ abstract class GeneratorTestCase extends TestCase
         unlink(storage_path('test.json'));
     }
 
-
     /** @test */
     public function uses_configured_settings_when_calling_route()
     {


### PR DESCRIPTION
File Response Strategy. Uses a file payload as response. Recommended for large responses.

You can define the transformer that is used for the result of the route using the @responseFile tag
@responseFile /apidoc_responses/search.json

The file must be in storage/apidoc_responses/search.json