### PR TITLE
Format PUT request body as urlencoded.

### DIFF
--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -38,6 +38,7 @@ class CollectionWriter
                     'description' => '',
                     'item' => $routes->map(function ($route) {
                         $mode = $route['methods'][0] === 'PUT' ? 'urlencoded' : 'formdata';
+
                         return [
                             'name' => $route['title'] != '' ? $route['title'] : url($route['uri']),
                             'request' => [

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -37,14 +37,15 @@ class CollectionWriter
                     'name' => $groupName,
                     'description' => '',
                     'item' => $routes->map(function ($route) {
+                        $mode = $route['methods'][0] === 'PUT' ? 'urlencoded' : 'formdata';
                         return [
                             'name' => $route['title'] != '' ? $route['title'] : url($route['uri']),
                             'request' => [
                                 'url' => url($route['uri']),
                                 'method' => $route['methods'][0],
                                 'body' => [
-                                    'mode' => 'formdata',
-                                    'formdata' => collect($route['bodyParameters'])->map(function ($parameter, $key) {
+                                    'mode' => $mode,
+                                    $mode => collect($route['bodyParameters'])->map(function ($parameter, $key) {
                                         return [
                                             'key' => $key,
                                             'value' => isset($parameter['value']) ? $parameter['value'] : '',


### PR DESCRIPTION
When I use Postman to PUT a request to laravel, the body variables are not accessible in PHP. As far as I can tell, simply setting the `mode` of the Postman object to "urlencoded" will import the required parameters properly so that they can be PUT as x-www-form-urlencoded Body data.