### PR TITLE
Fixed display of @fileResponse strategy

### DIFF
--- a/src/Tools/ResponseResolver.php
+++ b/src/Tools/ResponseResolver.php
@@ -75,6 +75,6 @@ class ResponseResolver
      */
     private function getResponseContent($response)
     {
-        return $response ? $response->getContent() : '';
+        return $response ? $response->getData() : '';
     }
 }

--- a/src/Tools/ResponseResolver.php
+++ b/src/Tools/ResponseResolver.php
@@ -75,6 +75,6 @@ class ResponseResolver
      */
     private function getResponseContent($response)
     {
-        return $response ? $response->getData() : '';
+        return $response ? $response->getContent() : '';
     }
 }

--- a/src/Tools/ResponseStrategies/ResponseFileStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseFileStrategy.php
@@ -32,9 +32,12 @@ class ResponseFileStrategy
      */
     protected function getFileResponses(array $tags)
     {
-        $responseFileTags = array_filter($tags, function ($tag) {
-            return $tag instanceof Tag && strtolower($tag->getName()) === 'responsefile';
-        });
+        // avoid "holes" in the keys of the filtered array, by using array_values on the filtered array
+        $responseFileTags = array_values(
+            array_filter($tags, function ($tag) {
+                return $tag instanceof Tag && strtolower($tag->getName()) === 'responsefile';
+            })
+        );
 
         if (empty($responseFileTags)) {
             return;

--- a/src/Tools/ResponseStrategies/ResponseTagStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseTagStrategy.php
@@ -32,9 +32,11 @@ class ResponseTagStrategy
      */
     protected function getDocBlockResponses(array $tags)
     {
-        $responseTags = array_filter($tags, function ($tag) {
-            return $tag instanceof Tag && strtolower($tag->getName()) === 'response';
-        });
+        $responseTags = array_values(
+            array_filter($tags, function ($tag) {
+                return $tag instanceof Tag && strtolower($tag->getName()) === 'response';
+            })
+        );
 
         if (empty($responseTags)) {
             return;

--- a/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
+++ b/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
@@ -127,9 +127,11 @@ class TransformerTagsStrategy
      */
     private function getTransformerTag(array $tags)
     {
-        $transFormerTags = array_filter($tags, function ($tag) {
-            return ($tag instanceof Tag) && in_array(strtolower($tag->getName()), ['transformer', 'transformercollection']);
-        });
+        $transFormerTags = array_values(
+            array_filter($tags, function ($tag) {
+                return ($tag instanceof Tag) && in_array(strtolower($tag->getName()), ['transformer', 'transformercollection']);
+            })
+        );
 
         return array_first($transFormerTags);
     }


### PR DESCRIPTION
Fixes #419 

The filtering of tags generates a non-associative array with "holes" in the keys ; fixed with a call to "array_values". And to display pretty JSON for the responses, I used JSONResponse's "getData" function instead of "getContent".

First pull request ever - so let me know if I did anything wrong...

Thanks!