### PR TITLE
Added ability to replace json key values in response file

### DIFF
--- a/src/Tools/ResponseStrategies/ResponseFileStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseFileStrategy.php
@@ -47,7 +47,7 @@ class ResponseFileStrategy
             preg_match('/^(\d{3})?\s?([\S]*[\s]*?)(\{.*\})?$/', $responseFileTag->getContent(), $result);
             $status = $result[1] ?: 200;
             $content = $result[2] ? file_get_contents(storage_path(trim($result[2])), true) : '{}';
-            $json = isset($result[3]) ? preg_replace("/'/", "\"", $result[3]) : "{}";
+            $json = !empty($result[3]) ? str_replace("'", "\"", $result[3]) : "{}";
             $merged = array_merge(json_decode($content, true), json_decode($json, true));
             return new JsonResponse($merged, (int) $status);
         }, $responseFileTags);

--- a/src/Tools/ResponseStrategies/ResponseFileStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseFileStrategy.php
@@ -44,12 +44,12 @@ class ResponseFileStrategy
         }
 
         return array_map(function (Tag $responseFileTag) {
-            preg_match('/^(\d{3})?\s?([\s\S]*)$/', $responseFileTag->getContent(), $result);
-
+            preg_match('/^(\d{3})?\s?([\S]*[\s]*?)(\{.*\})?$/', $responseFileTag->getContent(), $result);
             $status = $result[1] ?: 200;
-            $content = $result[2] ? file_get_contents(storage_path($result[2]), true) : '{}';
-
-            return new JsonResponse(json_decode($content, true), (int) $status);
+            $content = $result[2] ? file_get_contents(storage_path(trim($result[2])), true) : '{}';
+            $json = isset($result[3]) ? preg_replace("/'/", "\"", $result[3]) : "{}";
+            $merged = array_merge(json_decode($content, true), json_decode($json, true));
+            return new JsonResponse($merged, (int) $status);
         }, $responseFileTags);
     }
 }

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -207,4 +207,12 @@ class TestController extends Controller
     {
         return '';
     }
+
+    /**
+     * @responseFile response_test.json {"message" : "Serendipity"}
+     */
+    public function responseFileTagAndCustomJson()
+    {
+        return '';
+    }
 }

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -355,6 +355,31 @@ abstract class GeneratorTestCase extends TestCase
     }
 
     /** @test */
+    public function can_replace_key_value_pair_in_response_file()
+    {
+        // copy file to storage
+        $filePath = __DIR__.'/../Fixtures/response_test.json';
+        $fixtureFileJson = file_get_contents($filePath);
+        copy($filePath, storage_path('response_test.json'));
+
+        $route = $this->createRoute('GET', '/responseFileTagAndCustomJson', 'responseFileTagAndCustomJson');
+        $parsed = $this->generator->processRoute($route);
+        $response = array_first($parsed['response']);
+
+        $this->assertTrue(is_array($parsed));
+        $this->assertArrayHasKey('showresponse', $parsed);
+        $this->assertTrue($parsed['showresponse']);
+        $this->assertTrue(is_array($response));
+        $this->assertEquals(200, $response['status']);
+        $this->assertNotSame(
+            $response['content'],
+            $fixtureFileJson
+        );
+
+        unlink(storage_path('response_test.json'));
+    }
+
+    /** @test */
     public function can_parse_multiple_response_file_tags_with_status_codes()
     {
         // copy file to storage

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -355,7 +355,7 @@ abstract class GeneratorTestCase extends TestCase
     }
 
     /** @test */
-    public function can_replace_key_value_pair_in_response_file()
+    public function can_add_or_replace_key_value_pair_in_response_file()
     {
         // copy file to storage
         $filePath = __DIR__.'/../Fixtures/response_test.json';


### PR DESCRIPTION
Ability to replace json key value pair with specified values in the response tag

Example: This is my response file for a successful action like restore and delete

`{
    "status": "success",
    "status_code": 200,
    "message": "App(s) restored"
}`

Now the message key value can be replaced in the json file with the `User deleted`

`* @responseFile responses/apps/app.restore.200.json {"message": "User deleted"}`
To give this in documentation

`{
    "status": "success",
    "status_code": 200,
    "message": "User deleted"
}`

Closes #433