### PR TITLE
Custom serializer

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -34,6 +34,8 @@ return [
       * default null means no serializer or just json return.
       */
     'fractal' => [
+        // example:
+        // serializer' => League\Fractal\Serializer\JsonApiSerializer::class,
         'serializer' => null,
     ],
 

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -29,7 +29,7 @@ return [
      * -JsonApiSerializer
      */
     'fractal' => [
-        'serializer' => League\Fractal\Serializer\JsonApiSerializer::class,
+        'serializer' => League\Fractal\Serializer\ArraySerializer::class,
     ],
 
     /*

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -17,28 +17,6 @@ return [
      */
     'postman' => true,
 
-     /*
-      * Fractal Transformer Config
-      *
-      * this is require https://github.com/thephpleague/fractal
-      * composer require league/fractal
-      *
-      * If you are using custom serializer with league/fractal,
-      * you can specify it here.
-      *
-      * Available serializers:
-      * -League\Fractal\Serializer\ArraySerializer::class
-      * -League\Fractal\Serializer\DataArraySerializer::class
-      * -League\Fractal\Serializer\JsonApiSerializer::class
-      *
-      * default null means no serializer or just json return.
-      */
-    'fractal' => [
-        // example:
-        // serializer' => League\Fractal\Serializer\JsonApiSerializer::class,
-        'serializer' => null,
-    ],
-
     /*
      * The routes for which documentation should be generated.
      * Each group contains rules defining which routes should be included ('match', 'include' and 'exclude' sections)
@@ -176,4 +154,22 @@ return [
      * - size: 230 x 52
      */
     'logo' => false,
+    
+    /*
+     * Configure how responses are transformed using @transformer and @transformerCollection
+     * Requires league/fractal package: composer require league/fractal
+     *
+     * If you are using a custom serializer with league/fractal,
+     * you can specify it here.
+     *
+     * Serializers included with league/fractal:
+     * - \League\Fractal\Serializer\ArraySerializer::class
+     * - \League\Fractal\Serializer\DataArraySerializer::class
+     * - \League\Fractal\Serializer\JsonApiSerializer::class
+     *
+     * Leave as null to use no serializer or return a simple JSON.
+     */
+    'fractal' => [
+        'serializer' => null,
+    ],
 ];

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -24,12 +24,14 @@ return [
      * composer require league/fractal
      *
      * Available serializers:
-     * -ArraySerializer
-     * -DataArraySerializer
-     * -JsonApiSerializer
+     * -League\Fractal\Serializer\ArraySerializer::class
+     * -League\Fractal\Serializer\DataArraySerializer::class
+     * -League\Fractal\Serializer\JsonApiSerializer::class
+     *
+     * null means no serializer
      */
     'fractal' => [
-        'serializer' => League\Fractal\Serializer\ArraySerializer::class,
+        'serializer' => null,
     ],
 
     /*

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -18,18 +18,21 @@ return [
     'postman' => true,
 
      /*
-     * Fractal Transformer Config
-     *
-     * must install
-     * composer require league/fractal
-     *
-     * Available serializers:
-     * -League\Fractal\Serializer\ArraySerializer::class
-     * -League\Fractal\Serializer\DataArraySerializer::class
-     * -League\Fractal\Serializer\JsonApiSerializer::class
-     *
-     * null means no serializer
-     */
+      * Fractal Transformer Config
+      *
+      * this is require https://github.com/thephpleague/fractal
+      * composer require league/fractal
+      *
+      * If you are using custom serializer with league/fractal,
+      * you can specify it here.
+      *
+      * Available serializers:
+      * -League\Fractal\Serializer\ArraySerializer::class
+      * -League\Fractal\Serializer\DataArraySerializer::class
+      * -League\Fractal\Serializer\JsonApiSerializer::class
+      *
+      * default null means no serializer or just json return.
+      */
     'fractal' => [
         'serializer' => null,
     ],

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -16,6 +16,21 @@ return [
      * Generate a Postman collection in addition to HTML docs.
      */
     'postman' => true,
+    
+     /**
+     * Fractal Transformer Config
+     * 
+     * must install
+     * composer require league/fractal
+     *
+     * Available serializers:
+     * -ArraySerializer
+     * -DataArraySerializer
+     * -JsonApiSerializer
+     */
+    'fractal' => [
+        'serializer' => League\Fractal\Serializer\JsonApiSerializer::class,
+    ],
 
     /*
      * The routes for which documentation should be generated.

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -17,7 +17,7 @@ return [
      */
     'postman' => true,
 
-     /**
+     /*
      * Fractal Transformer Config
      *
      * must install

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -16,10 +16,10 @@ return [
      * Generate a Postman collection in addition to HTML docs.
      */
     'postman' => true,
-    
+
      /**
      * Fractal Transformer Config
-     * 
+     *
      * must install
      * composer require league/fractal
      *

--- a/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
+++ b/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
@@ -46,7 +46,7 @@ class TransformerTagsStrategy
             $modelInstance = $this->instantiateTransformerModel($model);
 
             $fractal = new Manager();
- 
+
             if (! is_null(config('apidoc.fractal.serializer'))) {
                 $fractal->setSerializer(app(config('apidoc.fractal.serializer')));
             }

--- a/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
+++ b/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
@@ -46,6 +46,7 @@ class TransformerTagsStrategy
             $modelInstance = $this->instantiateTransformerModel($model);
 
             $fractal = new Manager();
+            $fractal->setSerializer(app(config('apidoc.fractal.serializer')));
             $resource = (strtolower($transformerTag->getName()) == 'transformercollection')
                 ? new Collection([$modelInstance, $modelInstance], new $transformer)
                 : new Item($modelInstance, new $transformer);

--- a/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
+++ b/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
@@ -47,7 +47,7 @@ class TransformerTagsStrategy
 
             $fractal = new Manager();
  
-            if (!is_null(config('apidoc.fractal.serializer'))) {
+            if (! is_null(config('apidoc.fractal.serializer'))) {
                 $fractal->setSerializer(app(config('apidoc.fractal.serializer')));
             }
 

--- a/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
+++ b/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
@@ -46,11 +46,11 @@ class TransformerTagsStrategy
             $modelInstance = $this->instantiateTransformerModel($model);
 
             $fractal = new Manager();
-            
-            if(!is_null(config('apidoc.fractal.serializer'))) {
+ 
+            if (!is_null(config('apidoc.fractal.serializer'))) {
                 $fractal->setSerializer(app(config('apidoc.fractal.serializer')));
             }
-            
+
             $resource = (strtolower($transformerTag->getName()) == 'transformercollection')
                 ? new Collection([$modelInstance, $modelInstance], new $transformer)
                 : new Item($modelInstance, new $transformer);

--- a/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
+++ b/src/Tools/ResponseStrategies/TransformerTagsStrategy.php
@@ -46,7 +46,11 @@ class TransformerTagsStrategy
             $modelInstance = $this->instantiateTransformerModel($model);
 
             $fractal = new Manager();
-            $fractal->setSerializer(app(config('apidoc.fractal.serializer')));
+            
+            if(!is_null(config('apidoc.fractal.serializer'))) {
+                $fractal->setSerializer(app(config('apidoc.fractal.serializer')));
+            }
+            
             $resource = (strtolower($transformerTag->getName()) == 'transformercollection')
                 ? new Collection([$modelInstance, $modelInstance], new $transformer)
                 : new Item($modelInstance, new $transformer);

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -254,11 +254,11 @@ abstract class GeneratorTestCase extends TestCase
         return [
             [
                 null,
-                '{"data":{"id":1,"description":"Welcome on this test versions","name":"TestName"}}'
+                '{"data":{"id":1,"description":"Welcome on this test versions","name":"TestName"}}',
             ],
             [
                 'League\Fractal\Serializer\JsonApiSerializer',
-                '{"data":{"type":null,"id":"1","attributes":{"description":"Welcome on this test versions","name":"TestName"}}}'
+                '{"data":{"type":null,"id":"1","attributes":{"description":"Welcome on this test versions","name":"TestName"}}}',
             ],
         ];
     }

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -224,9 +224,16 @@ abstract class GeneratorTestCase extends TestCase
         ], json_decode($parsed['response'][1]['content'], true));
     }
 
-    /** @test */
-    public function can_parse_transformer_tag()
+    /**
+     * @param $serializer
+     * @param $expected
+     *
+     * @test
+     * @dataProvider dataResources
+     */
+    public function can_parse_transformer_tag($serializer, $expected)
     {
+        config(['apidoc.fractal.serializer' => $serializer]);
         $route = $this->createRoute('GET', '/transformerTag', 'transformerTag');
         $parsed = $this->generator->processRoute($route);
         $response = array_first($parsed['response']);
@@ -238,8 +245,22 @@ abstract class GeneratorTestCase extends TestCase
         $this->assertEquals(200, $response['status']);
         $this->assertSame(
             $response['content'],
-            '{"data":{"id":1,"description":"Welcome on this test versions","name":"TestName"}}'
+            $expected
         );
+    }
+
+    public function dataResources()
+    {
+        return [
+            [
+                null,
+                '{"data":{"id":1,"description":"Welcome on this test versions","name":"TestName"}}'
+            ],
+            [
+                'League\Fractal\Serializer\JsonApiSerializer',
+                '{"data":{"type":null,"id":"1","attributes":{"description":"Welcome on this test versions","name":"TestName"}}}'
+            ],
+        ];
     }
 
     /** @test */


### PR DESCRIPTION
this will dynamically generate format result by custom serializer from [league/fractal](https://github.com/thephpleague/fractal), it can be null ass default behavior.

```php
return [
//...
     /*
      * Fractal Transformer Config
      *
      * this is require https://github.com/thephpleague/fractal
      * composer require league/fractal
      *
      * If you are using custom serializer with league/fractal,
      * you can specify it here.
      *
      * Available serializers:
      * -League\Fractal\Serializer\ArraySerializer::class
      * -League\Fractal\Serializer\DataArraySerializer::class
      * -League\Fractal\Serializer\JsonApiSerializer::class
      *
      * default null means no serializer or just json return.
      */
    'fractal' => [
        'serializer' => null,
    ],
//...
```