### PR TITLE
New features for the Postman collections generation

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -30,6 +30,28 @@ return [
          * The description for the exported Postman collection.
          */
         'description' => null,
+
+        /**
+         * Postman Environment variables
+         * More info: https://learning.getpostman.com/docs/postman/environments_and_globals/manage_environments/
+         * If baseUrl is set then your API URI in Postman collection will look like: {{baseUrl}}/your/api/resource
+         * Set 'environment' => null to turn this feature off
+         */
+        'environment' => [
+            'variables' => [
+                'accessToken' => 'accessToken',
+                'refreshToken' => 'refreshToken',
+                'baseUrl' => 'baseUrl',
+                'email' => 'email',
+                'password' => 'password',
+            ],
+            // Auth response object key with access token string
+            'auth_response_access_token_key' => 'data.access_token',
+            'auth_response_refresh_token_key' => 'data.refresh_token',
+        ],
+
+        // Add API responses as Postman collection example
+        'add_response_example' => false,
     ],
 
     /*

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -38,11 +38,9 @@ return [
          */
         'environment' => [
             'variables' => [
+                'baseUrl' => 'baseUrl',
                 'accessToken' => 'accessToken',
                 'refreshToken' => 'refreshToken',
-                'baseUrl' => 'baseUrl',
-                'email' => 'email',
-                'password' => 'password',
             ],
             // Auth response object key with access token string
             'auth_response_access_token_key' => 'data.access_token',

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -20,7 +20,6 @@ return [
          * Specify whether the Postman collection should be generated.
          */
         'enabled' => true,
-
         /*
          * The name for the exported Postman collection. Default: config('app.name')." API"
          */
@@ -50,10 +49,12 @@ return [
             'auth_response_refresh_token_key' => 'data.refresh_token',
         ],
 
-        // Add API responses as Postman collection example
-        'add_response_example' => false,
-    ],
+        // Add API responses as Postman collection example. Default is false for the sake of security.
+        'add_response_example' => true,
 
+        // Exclude following HTTP headers from being populated to Postman request headers
+        'excluded_headers' => ['Authorization'],
+    ],
     /*
      * The routes for which documentation should be generated.
      * Each group contains rules defining which routes should be included ('match', 'include' and 'exclude' sections)

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -30,7 +30,7 @@ return [
          */
         'description' => null,
 
-        /**
+        /*
          * Postman Environment variables
          * More info: https://learning.getpostman.com/docs/postman/environments_and_globals/manage_environments/
          * If baseUrl is set then your API URI in Postman collection will look like: {{baseUrl}}/your/api/resource

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -143,7 +143,7 @@ class CollectionWriter
                 'schema' => 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json',
             ],
             'item' => $this->routeGroups->map(function ($routes, $group) {
-                list($groupName, $groupDescription) = explode("\n\n", $group);
+                list($groupName, $groupDescription) = array_pad(explode("\n\n", $group), 2, null);
 
                 return [
                     'name' => $groupName,

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -39,12 +39,12 @@ class CollectionWriter
      *
      * @return string
      */
-    function getRouteUri($route): string
+    protected function getRouteUri($route): string
     {
         if ($this->usePostmanEnvironment) {
             $baseUrl = config('apidoc.postman.environment.variables.baseUrl');
             if ($baseUrl) {
-                return '{{' . $baseUrl . '}}' . '/' . $route['uri'];
+                return '{{'.$baseUrl.'}}'.'/'.$route['uri'];
             } else {
                 return url($route['uri']);
             }
@@ -64,7 +64,7 @@ class CollectionWriter
     }
 
     /**
-     * Returns Auth response object key with refresh token string
+     * Returns Auth response object key with refresh token string.
      *
      * @return string
      */

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -144,6 +144,7 @@ class CollectionWriter
             ],
             'item' => $this->routeGroups->map(function ($routes, $group) {
                 list($groupName, $groupDescription) = explode("\n\n", $group);
+
                 return [
                     'name' => $groupName,
                     'description' => $groupDescription,

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -36,6 +36,7 @@ class CollectionWriter
 
     /**
      * @param $route
+     *
      * @return string
      */
     function getRouteUri($route): string
@@ -53,7 +54,7 @@ class CollectionWriter
     }
 
     /**
-     * Returns Auth response object key with access token string
+     * Returns Auth response object key with access token string.
      *
      * @return string
      */
@@ -96,7 +97,7 @@ class CollectionWriter
             'auth' => $route['authenticated'] ? [
                 'type' => 'bearer',
                 'bearer' => [
-                    'token' => '{{' . $this->getAccessTokenVariable() . '}}',
+                    'token' => '{{'.$this->getAccessTokenVariable().'}}',
                 ],
             ] : false,
             'url' => $this->getRouteUri($route),
@@ -118,7 +119,7 @@ class CollectionWriter
                 $mode => collect($route['bodyParameters'])->map(function ($parameter, $key) {
                     return [
                         'key' => $key,
-                        'value' => isset($parameter['value']) ? ($parameter['type'] === 'boolean' ? (string)$parameter['value'] : $parameter['value']) : '',
+                        'value' => isset($parameter['value']) ? ($parameter['type'] === 'boolean' ? (string) $parameter['value'] : $parameter['value']) : '',
                         'description' => implode(' | ', [($parameter['required'] ? 'required' : 'optional'), $parameter['type'], $parameter['description']]),
                         'type' => 'text',
                         'enabled' => true,
@@ -157,9 +158,9 @@ class CollectionWriter
                                     'id' => Uuid::uuid4()->toString(),
                                     'exec' => [
                                         'var response = JSON.parse(responseBody);',
-                                        'tests["Successfull POST request"] = responseCode.code === 200;',
-                                        'if (response.' . $this->getResponseAccessTokenKey() . ') { postman.setEnvironmentVariable("'. $this->getAccessTokenVariable() .'", response.' . $this->getResponseAccessTokenKey() . '); }',
-                                        'if (response.' . $this->getResponseRefreshTokenKey() . ') { postman.setEnvironmentVariable("'. $this->getRefreshTokenVariable() .'", response.' . $this->getResponseRefreshTokenKey() . '); }',
+                                        'tests["Successful request"] = responseCode.code === 200;',
+                                        'if (response.'.$this->getResponseAccessTokenKey().') { postman.setEnvironmentVariable("'.$this->getAccessTokenVariable().'", response.'.$this->getResponseAccessTokenKey().'); }',
+                                        'if (response.'.$this->getResponseRefreshTokenKey().') { postman.setEnvironmentVariable("'.$this->getRefreshTokenVariable().'", response.'.$this->getResponseRefreshTokenKey().'); }',
                                     ],
                                     'type' => 'text/javascript',
                                 ] : [],

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -35,31 +35,105 @@ class CollectionWriter
                 'description' => config('apidoc.postman.description') ?: '',
                 'schema' => 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json',
             ],
-            'item' => $this->routeGroups->map(function ($routes, $groupName) {
+            'item' => $this->routeGroups->map(function ($routes, $group) {
+                list($groupName, $groupDescription) = explode("\n\n", $group);
                 return [
                     'name' => $groupName,
-                    'description' => '',
+                    'description' => $groupDescription,
                     'item' => $routes->map(function ($route) {
                         $mode = $route['methods'][0] === 'PUT' ? 'urlencoded' : 'formdata';
 
                         return [
-                            'name' => $route['title'] != '' ? $route['title'] : url($route['uri']),
+                            'name' => $route['title'] != '' ? $route['title'] : '{{baseUrl}}/' . $route['uri'],
+                            'event' => [[
+                                'listen' => 'test',
+                                'script' => [
+                                    'id' => Uuid::uuid4()->toString(),
+                                    'exec' => [
+                                        'var response = JSON.parse(responseBody);',
+                                        'postman.setEnvironmentVariable("authToken", response.data.access_token);',
+                                        'tests["Successfull POST request"] = responseCode.code === 200;',
+                                        'tests["TokenType of correct type"] = response.data.token_type === "Bearer";',
+                                    ],
+                                    'type' => 'text/javascript',
+                                ],
+                            ]],
                             'request' => [
-                                'url' => url($route['uri']),
+                                'auth' => [
+                                    'type' => 'bearer',
+                                    'bearer' => [
+                                        'token' => '{{authToken}}',
+                                    ],
+                                ],
+                                'url' => '{{baseUrl}}/' . $route['uri'],
                                 'method' => $route['methods'][0],
+                                'header' => collect($route['headers'])->map(function ($header, $key) use ($route) {
+                                    return [
+                                        'key' => $key,
+                                        'name' => $key,
+                                        'type' => 'text',
+                                        'value' => $header,
+                                    ];
+                                })->values()->toArray(),
                                 'body' => [
                                     'mode' => $mode,
                                     $mode => collect($route['bodyParameters'])->map(function ($parameter, $key) {
                                         return [
                                             'key' => $key,
-                                            'value' => isset($parameter['value']) ? $parameter['value'] : '',
+                                            'value' => isset($parameter['value']) ? ($parameter['type'] === 'boolean' ? (string) $parameter['value'] : $parameter['value']) : '',
                                             'type' => 'text',
                                             'enabled' => true,
                                         ];
                                     })->values()->toArray(),
                                 ],
                                 'description' => $route['description'],
-                                'response' => [],
+                            ],
+                            'response' => [
+                                [
+                                    'name' => $route['title'] != '' ? $route['title'] : '{{baseUrl}}/' . $route['uri'],
+                                    'originalRequest' => [
+                                        'auth' => [
+                                            'type' => 'bearer',
+                                            'bearer' => [
+                                                'token' => '{{authToken}}',
+                                            ],
+                                        ],
+                                        'url' => '{{baseUrl}}/' . $route['uri'],
+                                        'method' => $route['methods'][0],
+                                        'header' => collect($route['headers'])->map(function ($header, $key) use ($route) {
+                                            return [
+                                                'key' => $key,
+                                                'name' => $key,
+                                                'type' => 'text',
+                                                'value' => $header,
+                                            ];
+                                        })->values()->toArray(),
+                                        'body' => [
+                                            'mode' => $mode,
+                                            $mode => collect($route['bodyParameters'])->map(function ($parameter, $key) {
+                                                return [
+                                                    'key' => $key,
+                                                    'value' => isset($parameter['value']) ? ($parameter['type'] === 'boolean' ? (string) $parameter['value'] : $parameter['value']) : '',
+                                                    'type' => 'text',
+                                                    'enabled' => true,
+                                                ];
+                                            })->values()->toArray(),
+                                        ],
+                                        'description' => $route['description'],
+                                    ],
+                                    'status' => $route['response'][0]['statusText'],
+                                    'code' => $route['response'][0]['status'],
+                                    '_postman_previewlanguage' => 'json',
+                                    'header' => collect($route['response'][0]['headers'])->map(function ($header, $key) use ($route) {
+                                        return [
+                                            'key' => $key,
+                                            'name' => $key,
+                                            'type' => 'text',
+                                            'value' => $header,
+                                        ];
+                                    })->values()->toArray(),
+                                    'body' => json_encode(json_decode($route['response'][0]['content']), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
+                                ],
                             ],
                         ];
                     })->toArray(),

--- a/src/Tools/ResponseResolver.php
+++ b/src/Tools/ResponseResolver.php
@@ -3,11 +3,11 @@
 namespace Mpociot\ApiDoc\Tools;
 
 use Illuminate\Routing\Route;
+use Symfony\Component\HttpFoundation\Response;
+use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseTagStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseCallStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseFileStrategy;
-use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseTagStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\TransformerTagsStrategy;
-use Symfony\Component\HttpFoundation\Response;
 
 class ResponseResolver
 {

--- a/src/Tools/ResponseResolver.php
+++ b/src/Tools/ResponseResolver.php
@@ -3,11 +3,11 @@
 namespace Mpociot\ApiDoc\Tools;
 
 use Illuminate\Routing\Route;
-use Symfony\Component\HttpFoundation\Response;
-use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseTagStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseCallStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseFileStrategy;
+use Mpociot\ApiDoc\Tools\ResponseStrategies\ResponseTagStrategy;
 use Mpociot\ApiDoc\Tools\ResponseStrategies\TransformerTagsStrategy;
+use Symfony\Component\HttpFoundation\Response;
 
 class ResponseResolver
 {
@@ -50,7 +50,12 @@ class ResponseResolver
 
             if (! is_null($responses)) {
                 return array_map(function (Response $response) {
-                    return [ 'headers' => $response->headers, 'statusText' => $response::$statusTexts[$response->getStatusCode()], 'status' => $response->getStatusCode(), 'content' => $this->getResponseContent($response)];
+                    return [
+                        'headers' => $response->headers,
+                        'statusText' => Response::$statusTexts[$response->getStatusCode()],
+                        'status' => $response->getStatusCode(),
+                        'content' => $this->getResponseContent($response),
+                    ];
                 }, $responses);
             }
         }

--- a/src/Tools/ResponseResolver.php
+++ b/src/Tools/ResponseResolver.php
@@ -50,7 +50,7 @@ class ResponseResolver
 
             if (! is_null($responses)) {
                 return array_map(function (Response $response) {
-                    return ['status' => $response->getStatusCode(), 'content' => $this->getResponseContent($response)];
+                    return [ 'headers' => $response->headers, 'statusText' => $response::$statusTexts[$response->getStatusCode()], 'status' => $response->getStatusCode(), 'content' => $this->getResponseContent($response)];
                 }, $responses);
             }
         }


### PR DESCRIPTION
New features:
- Adding support of [Postman environment variables] (optional)(https://learning.getpostman.com/docs/postman/environments_and_globals/intro_to_environments_and_globals/)
- Auth headers for routes with tag ```@authenticated```
- Populating to environment variables access and refresh tokens if they present in the API response.
- Optional save of route response to Postman collection as an ["example"](https://learning.getpostman.com/docs/postman/collections/examples/#what-is-an-example)
- Saving response headers
- Enhancement of response status info: code + text ```200 OK``` instead of just ```200```
- Splitting group name and group description into the name and description sections of the Postman collection