### PR TITLE
Fix domain name for the generated links

### DIFF
--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Console\Command;
 use Mpociot\Reflection\DocBlock;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\URL;
 use Mpociot\ApiDoc\Tools\Generator;
 use Mpociot\ApiDoc\Tools\RouteMatcher;
 use Mpociot\Documentarian\Documentarian;
@@ -46,6 +47,7 @@ class GenerateDocumentation extends Command
      */
     public function handle()
     {
+        URL::forceRootUrl(config('app.url'));
         $usingDingoRouter = strtolower(config('apidoc.router')) == 'dingo';
         if ($usingDingoRouter) {
             $routes = $this->routeMatcher->getDingoRoutesToBeDocumented(config('apidoc.routes'));

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -3,6 +3,7 @@
 namespace Mpociot\ApiDoc\Tests;
 
 use ReflectionException;
+use Illuminate\Support\Str;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use Orchestra\Testbench\TestCase;
@@ -228,6 +229,21 @@ class GenerateDocumentationTest extends TestCase
         $generatedCollection->info->_postman_id = '';
         $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection.json'));
         $this->assertEquals($generatedCollection, $fixtureCollection);
+    }
+
+    /** @test */
+    public function generated_postman_collection_domain_is_correct()
+    {
+        $domain = 'http://somedomain.test';
+        RouteFacade::get('/api/test', TestController::class.'@withEndpointDescription');
+
+        config(['app.url' => $domain]);
+        config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
+        $this->artisan('apidoc:generate');
+
+        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'));
+        $endpointUrl = $generatedCollection->item[0]->item[0]->request->url;
+        $this->assertTrue(Str::startsWith($endpointUrl, $domain));
     }
 
     /** @test */


### PR DESCRIPTION
There is a bug, that if you've set your APP_URL to something different than localhost (e.g. using valet), all documentation and Postman links, including the link to the Postman collection will be generated with localhost as domain name.

This PR forces Laravel to use the domain name set in your configuration in order to generate the links correctly.