### PR TITLE
[Feature] Allow bodyParams to be noted in a FormRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,27 @@ Note: a random value will be used as the value of each parameter in the example 
      */
 ```
 
+Note: You can also add the `@bodyParam` annotations to a `\Illuminate\Foundation\Http\FormRequest` subclass:
+
+```php
+/**
+ * @bodyParam title string required The title of the post.
+ * @bodyParam body string required The title of the post.
+ * @bodyParam type string The type of post to create. Defaults to 'textophonious'.
+ * @bodyParam author_id int the ID of the author
+ * @bodyParam thumbnail image This is required if the post type is 'imagelicious'.
+ */
+class MyRequest extends \Illuminate\Foundation\Http\FormRequest
+{
+
+}
+
+public function createPost(MyRequest $request)
+{
+    // ...
+}
+```
+
 ### Indicating auth status
 You can use the `@authenticated` annotation on a method to indicate if the endpoint is authenticated. A "Requires authentication" badge will be added to that route in the generated documentation.
 

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -84,7 +84,10 @@ class Generator
                 continue;
             }
 
-            $formRequestClass = new ReflectionClass($paramType->getName());
+            $formRequestClassName = version_compare(phpversion(), '7.1.0', '<')
+                ? $paramType->__toString()
+                : $paramType->getName();
+            $formRequestClass = new ReflectionClass($formRequestClassName);
             if ($formRequestClass->isSubclassOf(\Illuminate\Foundation\Http\FormRequest::class)) {
                 $formRequestDocBlock = new DocBlock($formRequestClass->getDocComment());
                 $bodyParametersFromDocBlock = $this->getBodyParametersFromDocBlock($formRequestDocBlock->getTags());

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -96,7 +96,11 @@ class Generator
 
         if ($cls) {
             $docBlock = new DocBlock($cls->getDocComment());
-            return $this->getBodyParametersFromDocBlock($docBlock->getTags());
+            $result = $this->getBodyParametersFromDocBlock($docBlock->getTags());
+
+            if (count($result)) {
+                return $result;
+            }
         }
 
         return $this->getBodyParametersFromDocBlock($tags);

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -84,12 +84,12 @@ class Generator
                 continue;
             }
 
-            $formRequestClassName = version_compare(phpversion(), '7.1.0', '<')
+            $parameterClassName = version_compare(phpversion(), '7.1.0', '<')
                 ? $paramType->__toString()
                 : $paramType->getName();
-            $formRequestClass = new ReflectionClass($formRequestClassName);
-            if ($formRequestClass->isSubclassOf(\Illuminate\Foundation\Http\FormRequest::class)) {
-                $formRequestDocBlock = new DocBlock($formRequestClass->getDocComment());
+            $parameterClass = new ReflectionClass($parameterClassName);
+            if ($parameterClass->isSubclassOf(\Illuminate\Foundation\Http\FormRequest::class)) {
+                $formRequestDocBlock = new DocBlock($parameterClass->getDocComment());
                 $bodyParametersFromDocBlock = $this->getBodyParametersFromDocBlock($formRequestDocBlock->getTags());
 
                 if (count($bodyParametersFromDocBlock)) {

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -81,7 +81,7 @@ class Generator
         /** @var ReflectionClass $cls */
         $cls = collect($method->getParameters())
             ->reduce(function ($carry, $param) use ($method) {
-                if (!$param->getType()) {
+                if (! $param->getType() ) {
                     return $carry;
                 }
 

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -58,6 +58,14 @@ class TestController extends Controller
     }
 
     /**
+     * @bodyParam direct_one string Is found directly on the method.
+     */
+    public function withNonCommentedFormRequestParameter(TestNonCommentedRequest $request)
+    {
+        return '';
+    }
+
+    /**
      * @queryParam location_id required The id of the location.
      * @queryParam user_id required The id of the user. Example: me
      * @queryParam page required The page number. Example: 4

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -52,6 +52,11 @@ class TestController extends Controller
         return '';
     }
 
+    public function withFormRequestParameter(TestRequest $request)
+    {
+        return '';
+    }
+
     /**
      * @queryParam location_id required The id of the location.
      * @queryParam user_id required The id of the user. Example: me

--- a/tests/Fixtures/TestNonCommentedRequest.php
+++ b/tests/Fixtures/TestNonCommentedRequest.php
@@ -1,0 +1,8 @@
+<?php namespace Mpociot\ApiDoc\Tests\Fixtures;
+
+use Dingo\Api\Http\FormRequest;
+
+class TestNonCommentedRequest extends FormRequest
+{
+
+}

--- a/tests/Fixtures/TestNonCommentedRequest.php
+++ b/tests/Fixtures/TestNonCommentedRequest.php
@@ -1,4 +1,6 @@
-<?php namespace Mpociot\ApiDoc\Tests\Fixtures;
+<?php
+
+namespace Mpociot\ApiDoc\Tests\Fixtures;
 
 use Dingo\Api\Http\FormRequest;
 

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -1,0 +1,22 @@
+<?php namespace Mpociot\ApiDoc\Tests\Fixtures;
+
+use Dingo\Api\Http\FormRequest;
+
+/**
+ * @bodyParam user_id int required The id of the user. Example: 9
+ * @bodyParam room_id string The id of the room.
+ * @bodyParam forever boolean Whether to ban the user forever. Example: false
+ * @bodyParam another_one number Just need something here.
+ * @bodyParam yet_another_param object required
+ * @bodyParam even_more_param array
+ * @bodyParam book.name string
+ * @bodyParam book.author_id integer
+ * @bodyParam book[pages_count] integer
+ * @bodyParam ids.* integer
+ * @bodyParam users.*.first_name string The first name of the user. Example: John
+ * @bodyParam users.*.last_name string The last name of the user. Example: Doe
+ */
+class TestRequest extends FormRequest
+{
+
+}

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -1,4 +1,6 @@
-<?php namespace Mpociot\ApiDoc\Tests\Fixtures;
+<?php
+
+namespace Mpociot\ApiDoc\Tests\Fixtures;
 
 use Dingo\Api\Http\FormRequest;
 

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -92,7 +92,7 @@ abstract class GeneratorTestCase extends TestCase
         $this->assertArraySubset([
             'direct_one' => [
                 'type' => 'string',
-                'description' => 'Is found directly on the method.'
+                'description' => 'Is found directly on the method.',
             ],
         ], $bodyParameters);
     }

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -84,6 +84,48 @@ abstract class GeneratorTestCase extends TestCase
     }
 
     /** @test */
+    public function can_parse_form_request_body_parameters()
+    {
+        $route = $this->createRoute('GET', '/api/test', 'withFormRequestParameter');
+        $bodyParameters = $this->generator->processRoute($route)['bodyParameters'];
+
+        $this->assertArraySubset([
+            'user_id' => [
+                'type' => 'integer',
+                'required' => true,
+                'description' => 'The id of the user.',
+                'value' => 9,
+            ],
+            'room_id' => [
+                'type' => 'string',
+                'required' => false,
+                'description' => 'The id of the room.',
+            ],
+            'forever' => [
+                'type' => 'boolean',
+                'required' => false,
+                'description' => 'Whether to ban the user forever.',
+                'value' => false,
+            ],
+            'another_one' => [
+                'type' => 'number',
+                'required' => false,
+                'description' => 'Just need something here.',
+            ],
+            'yet_another_param' => [
+                'type' => 'object',
+                'required' => true,
+                'description' => '',
+            ],
+            'even_more_param' => [
+                'type' => 'array',
+                'required' => false,
+                'description' => '',
+            ],
+        ], $bodyParameters);
+    }
+
+    /** @test */
     public function can_parse_query_parameters()
     {
         $route = $this->createRoute('GET', '/api/test', 'withQueryParameters');

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -84,6 +84,20 @@ abstract class GeneratorTestCase extends TestCase
     }
 
     /** @test */
+    public function it_ignores_non_commented_form_request()
+    {
+        $route = $this->createRoute('GET', '/api/test', 'withNonCommentedFormRequestParameter');
+        $bodyParameters = $this->generator->processRoute($route)['bodyParameters'];
+
+        $this->assertArraySubset([
+            'direct_one' => [
+                'type' => 'string',
+                'description' => 'Is found directly on the method.'
+            ],
+        ], $bodyParameters);
+    }
+
+    /** @test */
     public function can_parse_form_request_body_parameters()
     {
         $route = $this->createRoute('GET', '/api/test', 'withFormRequestParameter');


### PR DESCRIPTION
If the controller method has a FormRequest subclass as parameter, it will check there first if bodyParams are present in the docblock and fall back to the ones noted directly at the method.