### PR TITLE
feat: cookies added to response_call.

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -142,6 +142,13 @@ return [
                     ],
 
                     /*
+                     * Cookies which should be sent with the API call.
+                     */
+                    'cookies' => [
+                        // 'name' => 'value'
+                    ],
+
+                    /*
                      * Query parameters which should be sent with the API call.
                      */
                     'query' => [

--- a/src/Tools/ResponseStrategies/ResponseCallStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseCallStrategy.php
@@ -67,7 +67,8 @@ class ResponseCallStrategy
         $uri = $this->replaceUrlParameterBindings($route, $rulesToApply['bindings'] ?? []);
         $routeMethods = $this->getMethods($route);
         $method = array_shift($routeMethods);
-        $request = Request::create($uri, $method, [], [], [], $this->transformHeadersToServerVars($rulesToApply['headers'] ?? []));
+        $cookies = isset($rulesToApply['cookies']) ? $rulesToApply['cookies'] : [];
+        $request = Request::create($uri, $method, [], $cookies, [], $this->transformHeadersToServerVars($rulesToApply['headers'] ?? []));
         $request = $this->addHeaders($request, $route, $rulesToApply['headers'] ?? []);
 
         // Mix in parsed parameters with manually specified parameters.


### PR DESCRIPTION
When using response_call, setting has been added so that cookie can be set
It is designed to work even if the cookies parameter does not exist.