### PR TITLE
Allow override of the name 'general' for ungrouped routes

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -178,6 +178,11 @@ return [
     'logo' => false,
 
     /*
+     * Name for the group of routes which do not have a @group set.
+     */
+    'ungrouped_name' => 'general',
+
+    /*
      * Configure how responses are transformed using @transformer and @transformerCollection
      * Requires league/fractal package: composer require league/fractal
      *

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -247,7 +247,7 @@ class Generator
             }
         }
 
-        return 'general';
+        return config('apidoc.ungrouped_name') ?: 'general';
     }
 
     private function normalizeParameterType($type)


### PR DESCRIPTION
Ungrouped routes currently get pushed into a 'general' group. This PR allows the override of that name from within the config. This helps with things like Laravel Passport which publishes it's own routes and at present you're not able to override the group name.