### PR TITLE
Replace `env` section with `config`

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -103,7 +103,7 @@ return [
                 /*
                  * If no @response or @transformer declarations are found for the route,
                  * we'll try to get a sample response by attempting an API call.
-                 * Configure the settings for the API call here,
+                 * Configure the settings for the API call here.
                  */
                 'response_calls' => [
                     /*
@@ -122,14 +122,15 @@ return [
                     ],
 
                     /*
-                     * Environment variables which should be set for the API call.
+                     * Laravel config variables which should be set for the API call.
                      * This is a good place to ensure that notifications, emails
-                     * and other external services are not triggered during the documentation API calls
+                     * and other external services are not triggered
+                     * during the documentation API calls
                      */
-                    'env' => [
-                        'APP_ENV' => 'documentation',
-                        'APP_DEBUG' => false,
-                        // 'env_var' => 'value',
+                    'config' => [
+                        'app.env' => 'documentation',
+                        'app.debug' => false,
+                        // 'service.key' => 'value',
                     ],
 
                     /*

--- a/src/Tools/ResponseStrategies/ResponseCallStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseCallStrategy.php
@@ -52,6 +52,7 @@ class ResponseCallStrategy
     {
         $this->startDbTransaction();
         $this->setEnvironmentVariables($rulesToApply['env'] ?? []);
+        $this->setLaravelConfigs($rulesToApply['config'] ?? []);
     }
 
     /**
@@ -103,9 +104,10 @@ class ResponseCallStrategy
     }
 
     /**
-     * @param array $env
+     * @param array $config
      *
      * @return void
+     * @deprecated in favour of Laravel config variables
      */
     private function setEnvironmentVariables(array $env)
     {
@@ -114,6 +116,22 @@ class ResponseCallStrategy
 
             $_ENV[$name] = $value;
             $_SERVER[$name] = $value;
+        }
+    }
+
+    /**
+     * @param array $config
+     *
+     * @return void
+     */
+    private function setLaravelConfigs(array $config)
+    {
+        if (empty($config)) {
+            return;
+        }
+
+        foreach ($config as $name => $value) {
+            config([$name => $value]);
         }
     }
 


### PR DESCRIPTION
This is because Laravel loads values from the .env file before the generator has a chance to run, so env variables set there can't be changed. Also, the `env` helper caches variables. So the `env` section wasn't really changing any env variables.

In this PR, we leverage the fact that Laravel allows us to set config dynamically.