### PR TITLE
Fix call to undefined method forceRootUrl in lumen

### DIFF
--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -50,7 +50,7 @@ class GenerateDocumentation extends Command
     {
         try {
             URL::forceRootUrl(config('app.url'));
-        } catch (\Exception $e) {
+        } catch (\Error $e) {
             echo "Warning: Couldn't force base url as Lumen currently doesn't have the forceRootUrl method.\n";
             echo "You should probably double check URLs in your generated documentation.\n";
         }

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -25,7 +25,12 @@ class CollectionWriter
 
     public function getCollection()
     {
-        URL::forceRootUrl(config('app.url'));
+        try {
+            URL::forceRootUrl(config('app.url'));
+        } catch (\Error $e) {
+            echo "Warning: Couldn't force base url as Lumen currently doesn't have the forceRootUrl method.\n";
+            echo "You should probably double check URLs in your generated documentation.\n";
+        }
 
         $collection = [
             'variables' => [],


### PR DESCRIPTION
Calls to undefined methods are a subclass of `\Error` in PHP 7.

Hopefully this finally fixes #509