### PR TITLE
Include query parameters and headers in the generated Postman collection.

### DIFF
--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -65,7 +65,6 @@ class CollectionWriter
                                 'header' => collect($route['headers'])
                                     ->union([
                                         'Accept' => 'application/json',
-                                        'Content-Type' => 'application/json',
                                     ])
                                     ->map(function ($value, $header) {
                                         return [

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -72,7 +72,8 @@ class CollectionWriter
                                             'key' => $header,
                                             'value' => $value,
                                         ];
-                                    }),
+                                    })
+                                    ->values()->all(),
                                 'body' => [
                                     'mode' => $mode,
                                     $mode => collect($route['bodyParameters'])->map(function ($parameter, $key) {

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -56,7 +56,11 @@ class CollectionWriter
                         return [
                             'name' => $route['title'] != '' ? $route['title'] : url($route['uri']),
                             'request' => [
-                                'url' => url($route['uri']),
+                                'url' => url($route['uri']) . (collect($route['queryParameters'])->isEmpty()
+                                    ? ''
+                                    : '?' . collect($route['queryParameters'])->map(function ($parameter, $key) {
+                                        return $key . '=' . (isset($parameter['value']) ? $parameter['value'] : '');
+                                    })->join('&')),
                                 'method' => $route['methods'][0],
                                 'body' => [
                                     'mode' => $mode,

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -56,11 +56,11 @@ class CollectionWriter
                         return [
                             'name' => $route['title'] != '' ? $route['title'] : url($route['uri']),
                             'request' => [
-                                'url' => url($route['uri']) . (collect($route['queryParameters'])->isEmpty()
+                                'url' => url($route['uri']).(collect($route['queryParameters'])->isEmpty()
                                     ? ''
-                                    : '?' . collect($route['queryParameters'])->map(function ($parameter, $key) {
-                                        return $key . '=' . (isset($parameter['value']) ? $parameter['value'] : '');
-                                    })->join('&')),
+                                    : ('?'.collect($route['queryParameters'])->map(function ($parameter, $key) {
+                                        return $key.'='.(isset($parameter['value']) ? $parameter['value'] : '');
+                                    })->join('&'))),
                                 'method' => $route['methods'][0],
                                 'body' => [
                                     'mode' => $mode,

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -62,6 +62,12 @@ class CollectionWriter
                                         return $key.'='.(isset($parameter['value']) ? $parameter['value'] : '');
                                     })->join('&'))),
                                 'method' => $route['methods'][0],
+                                'header' => collect($route['headers'])->map(function ($value, $header) {
+                                    return [
+                                        'key' => $header,
+                                        'value' => $value,
+                                    ];
+                                }),
                                 'body' => [
                                     'mode' => $mode,
                                     $mode => collect($route['bodyParameters'])->map(function ($parameter, $key) {

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -58,9 +58,9 @@ class CollectionWriter
                             'request' => [
                                 'url' => url($route['uri']).(collect($route['queryParameters'])->isEmpty()
                                     ? ''
-                                    : ('?'.collect($route['queryParameters'])->map(function ($parameter, $key) {
+                                    : ('?'.implode('&', collect($route['queryParameters'])->map(function ($parameter, $key) {
                                         return $key.'='.(isset($parameter['value']) ? $parameter['value'] : '');
-                                    })->join('&'))),
+                                    })->all()))),
                                 'method' => $route['methods'][0],
                                 'header' => collect($route['headers'])
                                     ->union([

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -59,7 +59,7 @@ class CollectionWriter
                                 'url' => url($route['uri']).(collect($route['queryParameters'])->isEmpty()
                                     ? ''
                                     : ('?'.implode('&', collect($route['queryParameters'])->map(function ($parameter, $key) {
-                                        return $key.'='.(isset($parameter['value']) ? $parameter['value'] : '');
+                                        return $key.'='.($parameter['value'] ?? '');
                                     })->all()))),
                                 'method' => $route['methods'][0],
                                 'header' => collect($route['headers'])
@@ -78,7 +78,7 @@ class CollectionWriter
                                     $mode => collect($route['bodyParameters'])->map(function ($parameter, $key) {
                                         return [
                                             'key' => $key,
-                                            'value' => isset($parameter['value']) ? $parameter['value'] : '',
+                                            'value' => $parameter['value'] ?? '',
                                             'type' => 'text',
                                             'enabled' => true,
                                         ];

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -62,12 +62,17 @@ class CollectionWriter
                                         return $key.'='.(isset($parameter['value']) ? $parameter['value'] : '');
                                     })->join('&'))),
                                 'method' => $route['methods'][0],
-                                'header' => collect($route['headers'])->map(function ($value, $header) {
-                                    return [
-                                        'key' => $header,
-                                        'value' => $value,
-                                    ];
-                                }),
+                                'header' => collect($route['headers'])
+                                    ->union([
+                                        'Accept' => 'application/json',
+                                        'Content-Type' => 'application/json',
+                                    ])
+                                    ->map(function ($value, $header) {
+                                        return [
+                                            'key' => $header,
+                                            'value' => $value,
+                                        ];
+                                    }),
                                 'body' => [
                                     'mode' => $mode,
                                     $mode => collect($route['bodyParameters'])->map(function ($parameter, $key) {

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -20,10 +20,6 @@
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "key": "Content-Type",
-                                "value": "application/json"
                             }
                         ],
                         "body": {
@@ -42,10 +38,6 @@
                         "header": [
                             {
                                 "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "key": "Content-Type",
                                 "value": "application/json"
                             }
                         ],

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -1,1 +1,63 @@
-{"variables":[],"info":{"name":"Laravel API","_postman_id":"","description":"","schema":"https:\/\/schema.getpostman.com\/json\/collection\/v2.0.0\/collection.json"},"item":[{"name":"Group A","description":"","item":[{"name":"Example title.","request":{"url":"http:\/\/localhost\/api\/test","method":"GET","body":{"mode":"formdata","formdata":[]},"description":"This will be the long description.\nIt can also be multiple lines long.","response":[]}},{"name":"http:\/\/localhost\/api\/responseTag","request":{"url":"http:\/\/localhost\/api\/responseTag","method":"POST","body":{"mode":"formdata","formdata":[]},"description":"","response":[]}}]}]}
+{
+    "variables": [],
+    "info": {
+        "name": "Laravel API",
+        "_postman_id": "",
+        "description": "",
+        "schema": "https:\/\/schema.getpostman.com\/json\/collection\/v2.0.0\/collection.json"
+    },
+    "item": [
+        {
+            "name": "Group A",
+            "description": "",
+            "item": [
+                {
+                    "name": "Example title.",
+                    "request": {
+                        "url": "http:\/\/localhost\/api\/test",
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            }
+                        ],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": []
+                        },
+                        "description": "This will be the long description.\nIt can also be multiple lines long.",
+                        "response": []
+                    }
+                },
+                {
+                    "name": "http:\/\/localhost\/api\/responseTag",
+                    "request": {
+                        "url": "http:\/\/localhost\/api\/responseTag",
+                        "method": "POST",
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            }
+                        ],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": []
+                        },
+                        "description": "",
+                        "response": []
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Fixtures/collection_updated_url.json
+++ b/tests/Fixtures/collection_updated_url.json
@@ -20,10 +20,6 @@
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "key": "Content-Type",
-                                "value": "application/json"
                             }
                         ],
                         "body": {
@@ -42,10 +38,6 @@
                         "header": [
                             {
                                 "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "key": "Content-Type",
                                 "value": "application/json"
                             }
                         ],

--- a/tests/Fixtures/collection_with_body_parameters.json
+++ b/tests/Fixtures/collection_with_body_parameters.json
@@ -33,7 +33,7 @@
                                 },
                                 {
                                     "key": "room_id",
-                                    "value": "dolores",
+                                    "value": "consequatur",
                                     "type": "text",
                                     "enabled": true
                                 },
@@ -45,7 +45,7 @@
                                 },
                                 {
                                     "key": "another_one",
-                                    "value": 33.666154,
+                                    "value": 11613.31890586,
                                     "type": "text",
                                     "enabled": true
                                 },
@@ -63,25 +63,25 @@
                                 },
                                 {
                                     "key": "book.name",
-                                    "value": "eius",
+                                    "value": "consequatur",
                                     "type": "text",
                                     "enabled": true
                                 },
                                 {
                                     "key": "book.author_id",
-                                    "value": 16,
+                                    "value": 17,
                                     "type": "text",
                                     "enabled": true
                                 },
                                 {
                                     "key": "book[pages_count]",
-                                    "value": 16,
+                                    "value": 17,
                                     "type": "text",
                                     "enabled": true
                                 },
                                 {
                                     "key": "ids.*",
-                                    "value": 3,
+                                    "value": 17,
                                     "type": "text",
                                     "enabled": true
                                 },

--- a/tests/Fixtures/collection_with_body_parameters.json
+++ b/tests/Fixtures/collection_with_body_parameters.json
@@ -1,0 +1,113 @@
+{
+    "variables": [],
+    "info": {
+        "name": "Laravel API",
+        "_postman_id": "",
+        "description": "",
+        "schema": "https:\/\/schema.getpostman.com\/json\/collection\/v2.0.0\/collection.json"
+    },
+    "item": [
+        {
+            "name": "Group A",
+            "description": "",
+            "item": [
+                {
+                    "name": "http://localhost/api/withBodyParameters",
+                    "request": {
+                        "url": "http:\/\/localhost\/api\/withBodyParameters",
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            }
+                        ],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": [
+                                {
+                                    "key": "user_id",
+                                    "value": 9,
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "room_id",
+                                    "value": "dolores",
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "forever",
+                                    "value": false,
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "another_one",
+                                    "value": 33.666154,
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "yet_another_param",
+                                    "value": [],
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "even_more_param",
+                                    "value": [],
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "book.name",
+                                    "value": "eius",
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "book.author_id",
+                                    "value": 16,
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "book[pages_count]",
+                                    "value": 16,
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "ids.*",
+                                    "value": 3,
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "users.*.first_name",
+                                    "value": "John",
+                                    "type": "text",
+                                    "enabled": true
+                                },
+                                {
+                                    "key": "users.*.last_name",
+                                    "value": "Doe",
+                                    "type": "text",
+                                    "enabled": true
+                                }
+                            ]
+                        },
+                        "description": "",
+                        "response": []
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Fixtures/collection_with_body_parameters.json
+++ b/tests/Fixtures/collection_with_body_parameters.json
@@ -20,10 +20,6 @@
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "key": "Content-Type",
-                                "value": "application/json"
                             }
                         ],
                         "body": {

--- a/tests/Fixtures/collection_with_custom_headers.json
+++ b/tests/Fixtures/collection_with_custom_headers.json
@@ -12,34 +12,19 @@
             "description": "",
             "item": [
                 {
-                    "name": "Example title.",
+                    "name": "http://localhost/api/headers",
                     "request": {
-                        "url": "http:\/\/yourapp.app\/api\/test",
+                        "url": "http:\/\/localhost\/api\/headers",
                         "method": "GET",
                         "header": [
                             {
-                                "key": "Accept",
-                                "value": "application/json"
+                                "key": "Authorization",
+                                "value": "customAuthToken"
                             },
                             {
-                                "key": "Content-Type",
-                                "value": "application/json"
-                            }
-                        ],
-                        "body": {
-                            "mode": "formdata",
-                            "formdata": []
-                        },
-                        "description": "This will be the long description.\nIt can also be multiple lines long.",
-                        "response": []
-                    }
-                },
-                {
-                    "name": "http:\/\/yourapp.app\/api\/responseTag",
-                    "request": {
-                        "url": "http:\/\/yourapp.app\/api\/responseTag",
-                        "method": "POST",
-                        "header": [
+                                "key": "Custom-Header",
+                                "value": "NotSoCustom"
+                            },
                             {
                                 "key": "Accept",
                                 "value": "application/json"

--- a/tests/Fixtures/collection_with_custom_headers.json
+++ b/tests/Fixtures/collection_with_custom_headers.json
@@ -28,10 +28,6 @@
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "key": "Content-Type",
-                                "value": "application/json"
                             }
                         ],
                         "body": {

--- a/tests/Fixtures/collection_with_query_parameters.json
+++ b/tests/Fixtures/collection_with_query_parameters.json
@@ -1,0 +1,36 @@
+{
+    "variables": [],
+    "info": {
+        "name": "Laravel API",
+        "_postman_id": "",
+        "description": "",
+        "schema": "https:\/\/schema.getpostman.com\/json\/collection\/v2.0.0\/collection.json"
+    },
+    "item": [
+        {
+            "name": "Group A",
+            "description": "",
+            "item": [
+                {
+                    "name": "http://localhost/api/withQueryParameters",
+                    "request": {
+                        "url": "http:\/\/localhost\/api\/withQueryParameters?location_id=consequatur&user_id=me&page=4&filters=consequatur",
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": []
+                        },
+                        "description": "",
+                        "response": []
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -242,9 +242,9 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $this->artisan('apidoc:generate');
 
-        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'));
-        $generatedCollection->info->_postman_id = '';
-        $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection.json'));
+        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        $generatedCollection['info']['_postman_id'] = '';
+        $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection.json'), true);
         $this->assertEquals($generatedCollection, $fixtureCollection);
     }
 
@@ -273,9 +273,28 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $this->artisan('apidoc:generate');
 
-        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'));
-        $generatedCollection->info->_postman_id = '';
-        $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection_updated_url.json'));
+        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        $generatedCollection['info']['_postman_id'] = '';
+        $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection_updated_url.json'), true);
+        $this->assertEquals($generatedCollection, $fixtureCollection);
+    }
+
+    /** @test */
+    public function generated_postman_collection_can_append_custom_http_headers()
+    {
+        RouteFacade::get('/api/headers', TestController::class.'@checkCustomHeaders');
+        config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
+        config([
+            'apidoc.routes.0.apply.headers' => [
+                'Authorization' => 'customAuthToken',
+                'Custom-Header' => 'NotSoCustom',
+            ],
+        ]);
+        $this->artisan('apidoc:generate');
+
+        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        $generatedCollection['info']['_postman_id'] = '';
+        $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection_with_custom_headers.json'), true);
         $this->assertEquals($generatedCollection, $fixtureCollection);
     }
 

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -243,6 +243,7 @@ class GenerateDocumentationTest extends TestCase
         $this->artisan('apidoc:generate');
 
         $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        // The Postman ID varies from call to call; erase it to make the test data reproducible.
         $generatedCollection['info']['_postman_id'] = '';
         $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection.json'), true);
         $this->assertEquals($generatedCollection, $fixtureCollection);
@@ -274,6 +275,7 @@ class GenerateDocumentationTest extends TestCase
         $this->artisan('apidoc:generate');
 
         $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        // The Postman ID varies from call to call; erase it to make the test data reproducible.
         $generatedCollection['info']['_postman_id'] = '';
         $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection_updated_url.json'), true);
         $this->assertEquals($generatedCollection, $fixtureCollection);
@@ -293,6 +295,7 @@ class GenerateDocumentationTest extends TestCase
         $this->artisan('apidoc:generate');
 
         $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        // The Postman ID varies from call to call; erase it to make the test data reproducible.
         $generatedCollection['info']['_postman_id'] = '';
         $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection_with_custom_headers.json'), true);
         $this->assertEquals($generatedCollection, $fixtureCollection);
@@ -308,6 +311,7 @@ class GenerateDocumentationTest extends TestCase
         $this->artisan('apidoc:generate');
 
         $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        // The Postman ID varies from call to call; erase it to make the test data reproducible.
         $generatedCollection['info']['_postman_id'] = '';
         $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection_with_query_parameters.json'), true);
         $this->assertEquals($generatedCollection, $fixtureCollection);
@@ -323,6 +327,7 @@ class GenerateDocumentationTest extends TestCase
         $this->artisan('apidoc:generate');
 
         $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        // The Postman ID varies from call to call; erase it to make the test data reproducible.
         $generatedCollection['info']['_postman_id'] = '';
         $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection_with_body_parameters.json'), true);
         $this->assertEquals($generatedCollection, $fixtureCollection);

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -299,6 +299,19 @@ class GenerateDocumentationTest extends TestCase
     }
 
     /** @test */
+    public function generated_postman_collection_can_add_body_parameters()
+    {
+        RouteFacade::get('/api/withBodyParameters', TestController::class.'@withBodyParameters');
+        config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
+        $this->artisan('apidoc:generate');
+
+        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        $generatedCollection['info']['_postman_id'] = '';
+        $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection_with_body_parameters.json'), true);
+        $this->assertEquals($generatedCollection, $fixtureCollection);
+    }
+
+    /** @test */
     public function can_append_custom_http_headers()
     {
         RouteFacade::get('/api/headers', TestController::class.'@checkCustomHeaders');

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -299,9 +299,26 @@ class GenerateDocumentationTest extends TestCase
     }
 
     /** @test */
+    public function generated_postman_collection_can_have_query_parameters()
+    {
+        RouteFacade::get('/api/withQueryParameters', TestController::class.'@withQueryParameters');
+        // We want to have the same values for params each time
+        config(['apidoc.faker_seed' => 1234]);
+        config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
+        $this->artisan('apidoc:generate');
+
+        $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'), true);
+        $generatedCollection['info']['_postman_id'] = '';
+        $fixtureCollection = json_decode(file_get_contents(__DIR__.'/Fixtures/collection_with_query_parameters.json'), true);
+        $this->assertEquals($generatedCollection, $fixtureCollection);
+    }
+
+    /** @test */
     public function generated_postman_collection_can_add_body_parameters()
     {
         RouteFacade::get('/api/withBodyParameters', TestController::class.'@withBodyParameters');
+        // We want to have the same values for params each time
+        config(['apidoc.faker_seed' => 1234]);
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $this->artisan('apidoc:generate');
 


### PR DESCRIPTION
Fixes #485.