### PR TITLE
Make a few `ResponseCallStrategy` methods `protected`.

### DIFF
--- a/src/Tools/ResponseStrategies/ResponseCallStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseCallStrategy.php
@@ -71,7 +71,7 @@ class ResponseCallStrategy
      *
      * @return Request
      */
-    private function prepareRequest(Route $route, array $rulesToApply, array $bodyParams, array $queryParams)
+    protected function prepareRequest(Route $route, array $rulesToApply, array $bodyParams, array $queryParams)
     {
         $uri = Utils::getFullUrl($route, $rulesToApply['bindings'] ?? []);
         $routeMethods = $this->getMethods($route);
@@ -261,7 +261,7 @@ class ResponseCallStrategy
      *
      * @return \Illuminate\Http\JsonResponse|mixed|\Symfony\Component\HttpFoundation\Response
      */
-    private function makeApiCall(Request $request)
+    protected function makeApiCall(Request $request)
     {
         if (config('apidoc.router') == 'dingo') {
             $response = $this->callDingoRoute($request);
@@ -279,7 +279,7 @@ class ResponseCallStrategy
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    private function callLaravelRoute(Request $request): \Symfony\Component\HttpFoundation\Response
+    protected function callLaravelRoute(Request $request): \Symfony\Component\HttpFoundation\Response
     {
         $kernel = app(\Illuminate\Contracts\Http\Kernel::class);
         $response = $kernel->handle($request);


### PR DESCRIPTION
Motivation:

This lets me subclass `ResponseCallStrategy` and modify e.g. `makeApiCall` to do extra work before/after the request has been performed. Examples for "preflight" work would be creating a temporary user for the API call, preparing "fixtures" that the API call can return, etc.. "Post-flight" work could be sanitizing the output for inclusion in the API docs, e.g. if I want my response to a "POST" call to always have the same ID for the new object.