### PR TITLE
Allows users to exclude a parameter from having an example

### DIFF
--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -97,6 +97,19 @@ Note: a random value will be used as the value of each parameter in the example 
      */
 ```
 
+Note: To exclude a particular parameter from the generated examples (for all languages), you can annotate it with `No-example`. For instance:
+```php
+       /**
+        * @queryParam location_id required The id of the location. Example: 1
+        * @queryParam user_id required The id of the user. No-example
+        * @queryParam page required The page number. Example: 4
+        */
+```
+Outputs: 
+```bash
+curl -X GET -G "https://example.com/api?location_id=1&page=4"
+```
+
 Note: You can also add the `@queryParam` and `@bodyParam` annotations to a `\Illuminate\Foundation\Http\FormRequest` subclass instead, if you are using one in your controller method
 
 ```php

--- a/resources/views/partials/example-requests/bash.blade.php
+++ b/resources/views/partials/example-requests/bash.blade.php
@@ -1,6 +1,6 @@
 ```bash
-curl -X {{$route['methods'][0]}} {{$route['methods'][0] == 'GET' ? '-G ' : ''}}"{{ rtrim($baseUrl, '/')}}/{{ ltrim($route['boundUri'], '/') }}@if(count($route['queryParameters']))?@foreach($route['queryParameters'] as $attribute => $parameter)
-{{ urlencode($attribute) }}={{ urlencode($parameter['value']) }}@if(!$loop->last)&@endif
+curl -X {{$route['methods'][0]}} {{$route['methods'][0] == 'GET' ? '-G ' : ''}}"{{ rtrim($baseUrl, '/')}}/{{ ltrim($route['boundUri'], '/') }}@if(count($route['cleanQueryParameters']))?@foreach($route['cleanQueryParameters'] as $parameter => $value)
+{{ urlencode($parameter) }}={{ urlencode($value) }}@if(!$loop->last)&@endif
 @endforeach
 @endif" @if(count($route['headers']))\
 @foreach($route['headers'] as $header => $value)

--- a/resources/views/partials/example-requests/javascript.blade.php
+++ b/resources/views/partials/example-requests/javascript.blade.php
@@ -1,10 +1,10 @@
 ```javascript
 const url = new URL("{{ rtrim($baseUrl, '/') }}/{{ ltrim($route['boundUri'], '/') }}");
-@if(count($route['queryParameters']))
+@if(count($route['cleanQueryParameters']))
 
     let params = {
-    @foreach($route['queryParameters'] as $attribute => $parameter)
-        "{{ $attribute }}": "{{ $parameter['value'] }}",
+    @foreach($route['cleanQueryParameters'] as $parameter => $value)
+        "{{ $parameter }}": "{{ $value }}",
     @endforeach
     };
     Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));

--- a/resources/views/partials/route.blade.php
+++ b/resources/views/partials/route.blade.php
@@ -14,7 +14,6 @@
 @foreach($settings['languages'] as $language)
 @include("apidoc::partials.example-requests.$language")
 
-
 @endforeach
 
 @if(in_array('GET',$route['methods']) || (isset($route['showresponse']) && $route['showresponse']))

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -150,7 +150,7 @@ class Generator
 
                 $type = $this->normalizeParameterType($type);
                 list($description, $example) = $this->parseDescription($description, $type);
-                $value = is_null($example)  && !$this->shouldExcludeExample($tag) ? $this->generateDummyValue($type) : $example;
+                $value = is_null($example)  && ! $this->shouldExcludeExample($tag) ? $this->generateDummyValue($type) : $example;
 
                 return [$name => compact('type', 'description', 'required', 'value')];
             })->toArray();
@@ -225,7 +225,7 @@ class Generator
                 }
 
                 list($description, $value) = $this->parseDescription($description, 'string');
-                if (is_null($value) && !$this->shouldExcludeExample($tag)) {
+                if (is_null($value) && ! $this->shouldExcludeExample($tag)) {
                     $value = str_contains($description, ['number', 'count', 'page'])
                         ? $this->generateDummyValue('integer')
                         : $this->generateDummyValue('string');

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -149,7 +149,7 @@ class Generator
 
                 $type = $this->normalizeParameterType($type);
                 list($description, $example) = $this->parseDescription($description, $type);
-                $value = is_null($example) ? $this->generateDummyValue($type) : $example;
+                $value = is_null($example)  && !$this->shouldExcludeExample($tag) ? $this->generateDummyValue($type) : $example;
 
                 return [$name => compact('type', 'description', 'required', 'value')];
             })->toArray();
@@ -223,7 +223,7 @@ class Generator
                 }
 
                 list($description, $value) = $this->parseDescription($description, 'string');
-                if (is_null($value)) {
+                if (is_null($value) && !$this->shouldExcludeExample($tag)) {
                     $value = str_contains($description, ['number', 'count', 'page'])
                         ? $this->generateDummyValue('integer')
                         : $this->generateDummyValue('string');

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -132,6 +132,7 @@ class Generator
             })
             ->mapWithKeys(function ($tag) {
                 preg_match('/(.+?)\s+(.+?)\s+(required\s+)?(.*)/', $tag->getContent(), $content);
+                $content = preg_replace('/\s?No-example.?/', '', $content);
                 if (empty($content)) {
                     // this means only name and type were supplied
                     list($name, $type) = preg_split('/\s+/', $tag->getContent());
@@ -207,6 +208,7 @@ class Generator
             })
             ->mapWithKeys(function ($tag) {
                 preg_match('/(.+?)\s+(required\s+)?(.*)/', $tag->getContent(), $content);
+                $content = preg_replace('/\s?No-example.?/', '', $content);
                 if (empty($content)) {
                     // this means only name was supplied
                     list($name) = preg_split('/\s+/', $tag->getContent());

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -150,7 +150,7 @@ class Generator
 
                 $type = $this->normalizeParameterType($type);
                 list($description, $example) = $this->parseDescription($description, $type);
-                $value = is_null($example)  && ! $this->shouldExcludeExample($tag) ? $this->generateDummyValue($type) : $example;
+                $value = is_null($example) && ! $this->shouldExcludeExample($tag) ? $this->generateDummyValue($type) : $example;
 
                 return [$name => compact('type', 'description', 'required', 'value')];
             })->toArray();

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -131,7 +131,7 @@ class Generator
                 return $tag instanceof Tag && $tag->getName() === 'bodyParam';
             })
             ->filter(function (Tag $tag) {
-                return !$this->shouldExcludeExample($tag);
+                return ! $this->shouldExcludeExample($tag);
             })
             ->mapWithKeys(function ($tag) {
                 preg_match('/(.+?)\s+(.+?)\s+(required\s+)?(.*)/', $tag->getContent(), $content);
@@ -209,7 +209,7 @@ class Generator
                 return $tag instanceof Tag && $tag->getName() === 'queryParam';
             })
             ->filter(function (Tag $tag) {
-                return !$this->shouldExcludeExample($tag);
+                return ! $this->shouldExcludeExample($tag);
             })
             ->mapWithKeys(function ($tag) {
                 preg_match('/(.+?)\s+(required\s+)?(.*)/', $tag->getContent(), $content);
@@ -375,7 +375,7 @@ class Generator
 
     /**
      * Allows users to specify that we shouldn't generate an example for the parameter
-     * by writing 'No-example'
+     * by writing 'No-example'.
      *
      * @param Tag $tag
      *

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -130,9 +130,6 @@ class Generator
             ->filter(function ($tag) {
                 return $tag instanceof Tag && $tag->getName() === 'bodyParam';
             })
-            ->filter(function (Tag $tag) {
-                return ! $this->shouldExcludeExample($tag);
-            })
             ->mapWithKeys(function ($tag) {
                 preg_match('/(.+?)\s+(.+?)\s+(required\s+)?(.*)/', $tag->getContent(), $content);
                 if (empty($content)) {
@@ -207,9 +204,6 @@ class Generator
         $parameters = collect($tags)
             ->filter(function ($tag) {
                 return $tag instanceof Tag && $tag->getName() === 'queryParam';
-            })
-            ->filter(function (Tag $tag) {
-                return ! $this->shouldExcludeExample($tag);
             })
             ->mapWithKeys(function ($tag) {
                 preg_match('/(.+?)\s+(required\s+)?(.*)/', $tag->getContent(), $content);

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -130,6 +130,9 @@ class Generator
             ->filter(function ($tag) {
                 return $tag instanceof Tag && $tag->getName() === 'bodyParam';
             })
+            ->filter(function (Tag $tag) {
+                return !$this->shouldExcludeExample($tag);
+            })
             ->mapWithKeys(function ($tag) {
                 preg_match('/(.+?)\s+(.+?)\s+(required\s+)?(.*)/', $tag->getContent(), $content);
                 if (empty($content)) {
@@ -204,6 +207,9 @@ class Generator
         $parameters = collect($tags)
             ->filter(function ($tag) {
                 return $tag instanceof Tag && $tag->getName() === 'queryParam';
+            })
+            ->filter(function (Tag $tag) {
+                return !$this->shouldExcludeExample($tag);
             })
             ->mapWithKeys(function ($tag) {
                 preg_match('/(.+?)\s+(required\s+)?(.*)/', $tag->getContent(), $content);
@@ -365,6 +371,19 @@ class Generator
         }
 
         return [$description, $example];
+    }
+
+    /**
+     * Allows users to specify that we shouldn't generate an example for the parameter
+     * by writing 'No-example'
+     *
+     * @param Tag $tag
+     *
+     * @return bool Whether no example should be generated
+     */
+    private function shouldExcludeExample(Tag $tag)
+    {
+        return strpos($tag->getContent(), ' No-example') !== false;
     }
 
     /**

--- a/src/Tools/Traits/ParamHelpers.php
+++ b/src/Tools/Traits/ParamHelpers.php
@@ -14,6 +14,10 @@ trait ParamHelpers
     protected function cleanParams(array $params)
     {
         $values = [];
+        $params = array_filter($params, function ($details) {
+            return is_string($details['value']) && strlen($details['value']);
+        });
+
         foreach ($params as $name => $details) {
             $this->cleanValueFrom($name, $details['value'], $values);
         }

--- a/src/Tools/Traits/ParamHelpers.php
+++ b/src/Tools/Traits/ParamHelpers.php
@@ -15,7 +15,7 @@ trait ParamHelpers
     {
         $values = [];
         $params = array_filter($params, function ($details) {
-            return is_string($details['value']) && strlen($details['value']);
+            return ! is_null($details['value']);
         });
 
         foreach ($params as $name => $details) {

--- a/src/Tools/Traits/ParamHelpers.php
+++ b/src/Tools/Traits/ParamHelpers.php
@@ -5,7 +5,7 @@ namespace Mpociot\ApiDoc\Tools\Traits;
 trait ParamHelpers
 {
     /**
-     * Create proper arrays from dot-noted parameter names.
+     * Create proper arrays from dot-noted parameter names. Also filter out parameters which were excluded from having examples.
      *
      * @param array $params
      *

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -83,6 +83,16 @@ class TestController extends Controller
     }
 
     /**
+     * @bodyParam included string required Exists in examples. Example: 'Here'
+     * @bodyParam  excluded_body_param int Does not exist in examples. No-example
+     * @queryParam excluded_query_param Does not exist in examples. No-example
+     */
+    public function withExcludedExamples()
+    {
+        return '';
+    }
+
+    /**
      * @authenticated
      */
     public function withAuthenticatedTag()

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -229,7 +229,6 @@ abstract class GeneratorTestCase extends TestCase
         $this->assertArrayNotHasKey('excluded_body_param', $bodyParameters);
 
         $this->assertEmpty($queryParameters);
-
     }
 
     /** @test */

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -211,6 +211,28 @@ abstract class GeneratorTestCase extends TestCase
     }
 
     /** @test */
+    public function it_ignores_excluded_params()
+    {
+        $route = $this->createRoute('GET', '/api/test', 'withExcludedExamples');
+        $parsed = $this->generator->processRoute($route);
+        $bodyParameters = $parsed['bodyParameters'];
+        $queryParameters = $parsed['queryParameters'];
+
+        $this->assertArraySubset([
+            'included' => [
+                'required' => true,
+                'type' => 'string',
+                'description' => 'Exists in examples.',
+            ],
+        ], $bodyParameters);
+
+        $this->assertArrayNotHasKey('excluded_body_param', $bodyParameters);
+
+        $this->assertEmpty($queryParameters);
+
+    }
+
+    /** @test */
     public function can_parse_route_group()
     {
         $route = $this->createRoute('GET', '/api/test', 'dummy');

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -217,10 +217,30 @@ abstract class GeneratorTestCase extends TestCase
         $parsed = $this->generator->processRoute($route);
         $cleanBodyParameters = $parsed['cleanBodyParameters'];
         $cleanQueryParameters = $parsed['cleanQueryParameters'];
+        $bodyParameters = $parsed['bodyParameters'];
+        $queryParameters = $parsed['queryParameters'];
 
         $this->assertArrayHasKey('included', $cleanBodyParameters);
         $this->assertArrayNotHasKey('excluded_body_param', $cleanBodyParameters);
         $this->assertEmpty($cleanQueryParameters);
+
+        $this->assertArraySubset([
+            'included' => [
+                'required' => true,
+                'type' => 'string',
+                'description' => 'Exists in examples.',
+            ],
+            'excluded_body_param' => [
+                'type' => 'integer',
+                'description' => 'Does not exist in examples.'
+            ],
+        ], $bodyParameters);
+
+        $this->assertArraySubset([
+            'excluded_query_param' => [
+                'description' => 'Does not exist in examples.'
+            ],
+        ], $queryParameters);
     }
 
     /** @test */

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -215,20 +215,12 @@ abstract class GeneratorTestCase extends TestCase
     {
         $route = $this->createRoute('GET', '/api/test', 'withExcludedExamples');
         $parsed = $this->generator->processRoute($route);
-        $bodyParameters = $parsed['bodyParameters'];
-        $queryParameters = $parsed['queryParameters'];
+        $cleanBodyParameters = $parsed['cleanBodyParameters'];
+        $cleanQueryParameters = $parsed['cleanQueryParameters'];
 
-        $this->assertArraySubset([
-            'included' => [
-                'required' => true,
-                'type' => 'string',
-                'description' => 'Exists in examples.',
-            ],
-        ], $bodyParameters);
-
-        $this->assertArrayNotHasKey('excluded_body_param', $bodyParameters);
-
-        $this->assertEmpty($queryParameters);
+        $this->assertArrayHasKey('included', $cleanBodyParameters);
+        $this->assertArrayNotHasKey('excluded_body_param', $cleanBodyParameters);
+        $this->assertEmpty($cleanQueryParameters);
     }
 
     /** @test */

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -211,7 +211,7 @@ abstract class GeneratorTestCase extends TestCase
     }
 
     /** @test */
-    public function it_ignores_excluded_params()
+    public function it_does_not_generate_values_for_excluded_params_and_excludes_them_from_clean_params()
     {
         $route = $this->createRoute('GET', '/api/test', 'withExcludedExamples');
         $parsed = $this->generator->processRoute($route);

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -232,13 +232,13 @@ abstract class GeneratorTestCase extends TestCase
             ],
             'excluded_body_param' => [
                 'type' => 'integer',
-                'description' => 'Does not exist in examples.'
+                'description' => 'Does not exist in examples.',
             ],
         ], $bodyParameters);
 
         $this->assertArraySubset([
             'excluded_query_param' => [
-                'description' => 'Does not exist in examples.'
+                'description' => 'Does not exist in examples.',
             ],
         ], $queryParameters);
     }


### PR DESCRIPTION
- Includes 'No-example' in the doc-block
- Useful for optional params in the request, or those that conflict with other params (ie only one of two are allowed)
- Implement with a simple `strpos()` search

@mpociot If this is something you would consider adding I will add tests and documentation for this feature.