### PR TITLE
Correct URI in example request for PHP

### DIFF
--- a/resources/views/partials/example-requests/php.blade.php
+++ b/resources/views/partials/example-requests/php.blade.php
@@ -1,7 +1,7 @@
 ```php
 
 $client = new \GuzzleHttp\Client();
-$response = $client->{{ strtolower($route['methods'][0]) }}("{{ rtrim($baseUrl, '/') . '/' . $route['boundUri'] }}", [
+$response = $client->{{ strtolower($route['methods'][0]) }}("{{ rtrim($baseUrl, '/') . '/' . ltrim($route['boundUri'], '/') }}", [
 @if(!empty($route['headers']))
     'headers' => [
     @foreach($route['headers'] as $header => $value)


### PR DESCRIPTION
@mpociot Currently, in example request for PHP, the slash symbol ('/') is duplicated:
- Actual: `https://mydomain.com//v1/users`
- Expected: `https://mydomain.com/v1/users`