### PR TITLE
Fix missed references to removed helper functions

### DIFF
--- a/src/Tools/ResponseStrategies/ResponseCallStrategy.php
+++ b/src/Tools/ResponseStrategies/ResponseCallStrategy.php
@@ -3,6 +3,7 @@
 namespace Mpociot\ApiDoc\Tools\ResponseStrategies;
 
 use Dingo\Api\Dispatcher;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
@@ -330,7 +331,7 @@ class ResponseCallStrategy
         $prefix = 'HTTP_';
         foreach ($headers as $name => $value) {
             $name = strtr(strtoupper($name), '-', '_');
-            if (! starts_with($name, $prefix) && $name !== 'CONTENT_TYPE') {
+            if (! Str::startsWith($name, $prefix) && $name !== 'CONTENT_TYPE') {
                 $name = $prefix.$name;
             }
             $server[$name] = $value;

--- a/tests/Unit/RouteMatcherTest.php
+++ b/tests/Unit/RouteMatcherTest.php
@@ -102,7 +102,7 @@ class RouteMatcherTest extends TestCase
         $routes = $this->matcher->getRoutesToBeDocumented($routeRules);
         $this->assertCount(4, $routes);
         foreach ($routes as $route) {
-            $this->assertTrue(str_is('prefix1/*', $route['route']->uri()));
+            $this->assertTrue(Str::is('prefix1/*', $route['route']->uri()));
         }
 
         $routeRules[0]['match']['prefixes'] = ['prefix2/*'];


### PR DESCRIPTION
Hey

The previous pr https://github.com/mpociot/laravel-apidoc-generator/pull/572 missed a couple of references to the removed helper functions.
The fix in `ResponseCallStrategy` allowed it to generate docs in my Laravel 6 project.