### PR TITLE
feat(Lumen Support): Use the Lumen kernel to send requests when HttpKernel is not bound

### DIFF
--- a/src/Strategies/Responses/ResponseCalls.php
+++ b/src/Strategies/Responses/ResponseCalls.php
@@ -286,9 +286,16 @@ class ResponseCalls extends Strategy
      */
     protected function callLaravelRoute(Request $request): \Symfony\Component\HttpFoundation\Response
     {
-        $kernel = app(\Illuminate\Contracts\Http\Kernel::class);
-        $response = $kernel->handle($request);
-        $kernel->terminate($request, $response);
+        // Confirm we're running in Laravel, not Lumen
+        if(app()->bound(\Illuminate\Contracts\Http\Kernel::class)){
+            $kernel = app(\Illuminate\Contracts\Http\Kernel::class);
+            $response = $kernel->handle($request);
+            $kernel->terminate($request, $response);
+        } else {
+            // Handle the request using the Lumen application.
+            $kernel = app();
+            $response = $kernel->handle($request);
+        }
 
         return $response;
     }


### PR DESCRIPTION
Lumen applications receive an error when `ResponseCalls.php` attempts this function:

```php
$kernel = app(\Illuminate\Contracts\Http\Kernel::class);
```

Rather than use a Kernel, Lumen apps call `handle()` directly on the application.  This PR confirms whether or not the `HttpKernel` contract is actually bound (which it is in Laravel environments) and falls back on the Lumen kernel if it is not.