### PR TITLE
Update documenting.md

### DIFF
--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -2,7 +2,7 @@
 This package generates documentation from your code using mainly annotations (in doc block comments).
 
 ## Grouping endpoints
-All endpoints are grouped for easy organization. Using `@group` in a controller doc block creates a Group within the API documentation. All routes handled by that controller will be grouped under this group in the table of conetns shown in the sidebar. 
+All endpoints are grouped for easy organization. Using `@group` in a controller doc block creates a Group within the API documentation. All routes handled by that controller will be grouped under this group in the table of contents shown in the sidebar. 
 
 The short description after the `@group` should be unique to allow anchor tags to navigate to this section. A longer description can be included below. Custom formatting and `<aside>` tags are also supported. (see the [Documentarian docs](http://marcelpociot.de/documentarian/installation/markdown_syntax))
 


### PR DESCRIPTION
Fixed a small spelling error in the file docs/documenting.md
In line 5. Changed the word "conetns" to "contents"