### PR TITLE
Changes to response_calls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,0 @@
-Major
-- Should `routes.*.apply.response_calls.headers` be replaced by `routes.*.apply.headers`? yes
-- Should we move HTML generation from Blade to fully PHP? (L)

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -103,6 +103,8 @@ return [
                  * Specify headers to be added to the example requests
                  */
                 'headers' => [
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'application/json',
                     // 'Authorization' => 'Bearer {token}',
                     // 'Api-Version' => 'v2',
                 ],
@@ -129,15 +131,6 @@ return [
                         'app.env' => 'documentation',
                         'app.debug' => false,
                         // 'service.key' => 'value',
-                    ],
-
-                    /*
-                     * Headers which should be sent with the API call.
-                     */
-                    'headers' => [
-                        'Content-Type' => 'application/json',
-                        'Accept' => 'application/json',
-                        // 'key' => 'value',
                     ],
 
                     /*

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -143,14 +143,14 @@ return [
                     /*
                      * Query parameters which should be sent with the API call.
                      */
-                    'query' => [
+                    'queryParams' => [
                         // 'key' => 'value',
                     ],
 
                     /*
                      * Body parameters which should be sent with the API call.
                      */
-                    'body' => [
+                    'bodyParams' => [
                         // 'key' => 'value',
                     ],
                 ],

--- a/docs/config.md
+++ b/docs/config.md
@@ -214,7 +214,7 @@ These values support wildcards and paths, so you can have `'exclude' => ['users/
 After defining the routes in `match` (and `include` or `exclude`), `apply` is where you specify the settings to be applied to those routes when generating documentation. There are a bunch of settings you can tweak here:
 
 #### `headers`
-Like we've demonstrated above, any headers you specify here will be added to the headers shown in the example requests in your documenation. Headers are specified as key => value strings.
+Like we've demonstrated above, any headers you specify here will be added to the headers shown in the example requests in your documenation. They will also be included in ["response calls"](documenting.html#generating-responses-automatically). Headers are specified as key => value strings.
 
 #### `response_calls`
 These are the settings that will be applied when making ["response calls"](documenting.html#generating-responses-automatically). See the linked section for details.

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -315,8 +315,6 @@ If you don't specify an example response using any of the above means, this pack
 
 - By default, response calls are only made for GET routes, but you can configure this. Set the `methods` key to an array of methods or '*' to mean all methods. Leave it as an empty array to turn off response calls for that route group.
 
-- Parameters in URLs (example: `/users/{user}`, `/orders/{id?}`) will be replaced with '1' by default. You can configure this, however. Put the parameter names (including curly braces and question marks) as the keys and their replacements as the values in the `bindings` key. You may also specify the preceding path, to allow for variations; for instance, you can set `['users/{id}' => 1, 'apps/{id}' => 'htTviP']`. However, there must only be one parameter per path (ie `users/{name}/{id}` is invalid).
-
 - You can set Laravel config variables. This is useful so you can prevent external services like notifications from being triggered. By default the `app.env` is set to 'documentation'. You can add more variables in the `config` key.
 
-- By default, the package will generate dummy values for your documented body and query parameters and send in the request. (If you specified example values using `@bodyParam` or `@queryParam`, those will be used instead.) You can configure what headers and additional query and parameters should be sent when making the request (the `headers`, `query`, and `body` keys respectively).
+- By default, the package will generate dummy values for your documented body and query parameters and send in the request. If you specified example values using `@bodyParam` or `@queryParam`, those will be used instead. You can configure additional parameters or overwrite the existing ones for the request in the `queryParams`, and `bodyParams` sections.

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -113,6 +113,7 @@ class GenerateDocumentation extends Command
         $parsedRouteOutput = $parsedRoutes->map(function ($routeGroup) use ($settings) {
             return $routeGroup->map(function ($route) use ($settings) {
                 if (count($route['cleanBodyParameters']) && ! isset($route['headers']['Content-Type'])) {
+                    // Set content type if the user forgot to set it
                     $route['headers']['Content-Type'] = 'application/json';
                 }
                 $route['output'] = (string) view('apidoc::partials.route')
@@ -230,7 +231,7 @@ class GenerateDocumentation extends Command
             $route = $routeItem['route'];
             /** @var Route $route */
             if ($this->isValidRoute($route) && $this->isRouteVisibleForDocumentation($route->getAction())) {
-                $parsedRoutes[] = $generator->processRoute($route, $routeItem['apply']);
+                $parsedRoutes[] = $generator->processRoute($route, $routeItem['apply'] ?? []);
                 $this->info('Processed route: ['.implode(',', $generator->getMethods($route)).'] '.$generator->getUri($route));
             } else {
                 $this->warn('Skipping route: ['.implode(',', $generator->getMethods($route)).'] '.$generator->getUri($route));

--- a/src/Strategies/Responses/ResponseCalls.php
+++ b/src/Strategies/Responses/ResponseCalls.php
@@ -38,8 +38,8 @@ class ResponseCalls extends Strategy
         $this->configureEnvironment($rulesToApply);
 
         // Mix in parsed parameters with manually specified parameters.
-        $bodyParameters = array_merge($context['cleanBodyParameters'], $rulesToApply['body'] ?? []);
-        $queryParameters = array_merge($context['cleanQueryParameters'], $rulesToApply['query'] ?? []);
+        $bodyParameters = array_merge($context['cleanBodyParameters'], $rulesToApply['bodyParams'] ?? []);
+        $queryParameters = array_merge($context['cleanQueryParameters'], $rulesToApply['queryParams'] ?? []);
         $urlParameters = $context['cleanUrlParameters'];
         $request = $this->prepareRequest($route, $rulesToApply, $urlParameters, $bodyParameters, $queryParameters, $routeRules['headers'] ?? []);
 

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -43,11 +43,11 @@ class Generator
 
     /**
      * @param \Illuminate\Routing\Route $route
-     * @param array $rulesToApply Rules to apply when generating documentation for this route
+     * @param array $routeRules Rules to apply when generating documentation for this route
      *
      * @return array
      */
-    public function processRoute(Route $route, array $rulesToApply = [])
+    public function processRoute(Route $route, array $routeRules = [])
     {
         list($controllerName, $methodName) = Utils::getRouteClassAndMethodNames($route->getAction());
         $controller = new ReflectionClass($controllerName);
@@ -58,27 +58,27 @@ class Generator
             'methods' => $this->getMethods($route),
             'uri' => $this->getUri($route),
         ];
-        $metadata = $this->fetchMetadata($controller, $method, $route, $rulesToApply, $parsedRoute);
+        $metadata = $this->fetchMetadata($controller, $method, $route, $routeRules, $parsedRoute);
         $parsedRoute['metadata'] = $metadata;
 
-        $urlParameters = $this->fetchUrlParameters($controller, $method, $route, $rulesToApply, $parsedRoute);
+        $urlParameters = $this->fetchUrlParameters($controller, $method, $route, $routeRules, $parsedRoute);
         $parsedRoute['urlParameters'] = $urlParameters;
         $parsedRoute['cleanUrlParameters'] = $this->cleanParams($urlParameters);
         $parsedRoute['boundUri'] = Utils::getFullUrl($route, $parsedRoute['cleanUrlParameters']);
 
-        $queryParameters = $this->fetchQueryParameters($controller, $method, $route, $rulesToApply, $parsedRoute);
+        $queryParameters = $this->fetchQueryParameters($controller, $method, $route, $routeRules, $parsedRoute);
         $parsedRoute['queryParameters'] = $queryParameters;
         $parsedRoute['cleanQueryParameters'] = $this->cleanParams($queryParameters);
 
-        $bodyParameters = $this->fetchBodyParameters($controller, $method, $route, $rulesToApply, $parsedRoute);
+        $bodyParameters = $this->fetchBodyParameters($controller, $method, $route, $routeRules, $parsedRoute);
         $parsedRoute['bodyParameters'] = $bodyParameters;
         $parsedRoute['cleanBodyParameters'] = $this->cleanParams($bodyParameters);
 
-        $responses = $this->fetchResponses($controller, $method, $route, $rulesToApply, $parsedRoute);
+        $responses = $this->fetchResponses($controller, $method, $route, $routeRules, $parsedRoute);
         $parsedRoute['response'] = $responses;
         $parsedRoute['showresponse'] = ! empty($responses);
 
-        $parsedRoute['headers'] = $rulesToApply['headers'] ?? [];
+        $parsedRoute['headers'] = $routeRules['headers'] ?? [];
 
         $parsedRoute += $metadata;
 

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -153,7 +153,9 @@ class TestController extends Controller
      */
     public function withEloquentApiResourceCollection()
     {
-        return TestUserApiResource::collection(factory(TestUser::class)->make(['id' => 0]));
+        return TestUserApiResource::collection(
+            collect([factory(TestUser::class)->make(['id' => 0])])
+        );
     }
 
     /**
@@ -164,7 +166,9 @@ class TestController extends Controller
      */
     public function withEloquentApiResourceCollectionClass()
     {
-        return new TestUserApiResourceCollection(factory(TestUser::class)->make(['id' => 0]));
+        return new TestUserApiResourceCollection(
+            collect([factory(TestUser::class)->make(['id' => 0])])
+        );
     }
 
     public function checkCustomHeaders(Request $request)

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -28,6 +28,10 @@
                             {
                                 "key": "Accept",
                                 "value": "application\/json"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application\/json"
                             }
                         ],
                         "body": {
@@ -55,6 +59,10 @@
                             {
                                 "key": "Accept",
                                 "value": "application\/json"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application\/json"
                             }
                         ],
                         "body": {
@@ -81,6 +89,10 @@
                             },
                             {
                                 "key": "Accept",
+                                "value": "application\/json"
+                            },
+                            {
+                                "key": "Content-Type",
                                 "value": "application\/json"
                             }
                         ],
@@ -194,6 +206,10 @@
                             {
                                 "key": "Accept",
                                 "value": "application\/json"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application\/json"
                             }
                         ],
                         "body": {
@@ -220,6 +236,10 @@
                             },
                             {
                                 "key": "Accept",
+                                "value": "application\/json"
+                            },
+                            {
+                                "key": "Content-Type",
                                 "value": "application\/json"
                             }
                         ],
@@ -248,6 +268,10 @@
                             {
                                 "key": "Accept",
                                 "value": "application\/json"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application\/json"
                             }
                         ],
                         "body": {
@@ -274,6 +298,10 @@
                             },
                             {
                                 "key": "Accept",
+                                "value": "application\/json"
+                            },
+                            {
+                                "key": "Content-Type",
                                 "value": "application\/json"
                             }
                         ],
@@ -308,6 +336,10 @@
                             {
                                 "key": "Accept",
                                 "value": "application\/json"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application\/json"
                             }
                         ],
                         "body": {
@@ -334,6 +366,10 @@
                             },
                             {
                                 "key": "Accept",
+                                "value": "application\/json"
+                            },
+                            {
+                                "key": "Content-Type",
                                 "value": "application\/json"
                             }
                         ],

--- a/tests/Fixtures/collection_updated_url.json
+++ b/tests/Fixtures/collection_updated_url.json
@@ -18,8 +18,12 @@
                         "method": "GET",
                         "header": [
                             {
+                                "key": "Content-Type",
+                                "value": "application\/json"
+                            },
+                            {
                                 "key": "Accept",
-                                "value": "application/json"
+                                "value": "application\/json"
                             }
                         ],
                         "body": {
@@ -37,8 +41,12 @@
                         "method": "POST",
                         "header": [
                             {
+                                "key": "Content-Type",
+                                "value": "application\/json"
+                            },
+                            {
                                 "key": "Accept",
-                                "value": "application/json"
+                                "value": "application\/json"
                             }
                         ],
                         "body": {

--- a/tests/Fixtures/collection_with_body_parameters.json
+++ b/tests/Fixtures/collection_with_body_parameters.json
@@ -18,6 +18,10 @@
                         "method": "GET",
                         "header": [
                             {
+                                "key": "Content-Type",
+                                "value": "application\/json"
+                            },
+                            {
                                 "key": "Accept",
                                 "value": "application\/json"
                             }

--- a/tests/Fixtures/collection_with_query_parameters.json
+++ b/tests/Fixtures/collection_with_query_parameters.json
@@ -12,14 +12,18 @@
             "description": "",
             "item": [
                 {
-                    "name": "http://localhost/api/withQueryParameters",
+                    "name": "http:\/\/localhost\/api\/withQueryParameters",
                     "request": {
                         "url": "http:\/\/localhost\/api\/withQueryParameters?location_id=consequatur&user_id=me&page=4&filters=consequatur&url_encoded=%2B+%5B%5D%26%3D",
                         "method": "GET",
                         "header": [
                             {
+                                "key": "Content-Type",
+                                "value": "application\/json"
+                            },
+                            {
                                 "key": "Accept",
-                                "value": "application/json"
+                                "value": "application\/json"
                             }
                         ],
                         "body": {

--- a/tests/Fixtures/collection_with_secure_url.json
+++ b/tests/Fixtures/collection_with_secure_url.json
@@ -18,8 +18,12 @@
                         "method": "GET",
                         "header": [
                             {
+                                "key": "Content-Type",
+                                "value": "application\/json"
+                            },
+                            {
                                 "key": "Accept",
-                                "value": "application/json"
+                                "value": "application\/json"
                             }
                         ],
                         "body": {
@@ -37,8 +41,12 @@
                         "method": "POST",
                         "header": [
                             {
+                                "key": "Content-Type",
+                                "value": "application\/json"
+                            },
+                            {
                                 "key": "Accept",
-                                "value": "application/json"
+                                "value": "application\/json"
                             }
                         ],
                         "body": {

--- a/tests/Fixtures/index.md
+++ b/tests/Fixtures/index.md
@@ -35,7 +35,9 @@ It can also be multiple lines long.
 curl -X GET \
     -G "http://localhost/api/withDescription" \
     -H "Authorization: customAuthToken" \
-    -H "Custom-Header: NotSoCustom"
+    -H "Custom-Header: NotSoCustom" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
 ```
 
 ```javascript
@@ -46,8 +48,8 @@ const url = new URL(
 let headers = {
     "Authorization": "customAuthToken",
     "Custom-Header": "NotSoCustom",
-    "Accept": "application/json",
     "Content-Type": "application/json",
+    "Accept": "application/json",
 };
 
 fetch(url, {
@@ -79,7 +81,9 @@ null
 curl -X GET \
     -G "http://localhost/api/withResponseTag" \
     -H "Authorization: customAuthToken" \
-    -H "Custom-Header: NotSoCustom"
+    -H "Custom-Header: NotSoCustom" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
 ```
 
 ```javascript
@@ -90,8 +94,8 @@ const url = new URL(
 let headers = {
     "Authorization": "customAuthToken",
     "Custom-Header": "NotSoCustom",
-    "Accept": "application/json",
     "Content-Type": "application/json",
+    "Accept": "application/json",
 };
 
 fetch(url, {
@@ -133,6 +137,7 @@ curl -X GET \
     -H "Authorization: customAuthToken" \
     -H "Custom-Header: NotSoCustom" \
     -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
     -d '{"user_id":9,"room_id":"consequatur","forever":false,"another_one":11613.31890586,"yet_another_param":{"name":"consequatur"},"even_more_param":[11613.31890586],"book":{"name":"consequatur","author_id":17,"pages_count":17},"ids":[17],"users":[{"first_name":"John","last_name":"Doe"}]}'
 
 ```
@@ -223,7 +228,9 @@ Parameter | Type | Status | Description
 curl -X GET \
     -G "http://localhost/api/withQueryParameters?location_id=consequatur&user_id=me&page=4&filters=consequatur&url_encoded=%2B+%5B%5D%26%3D" \
     -H "Authorization: customAuthToken" \
-    -H "Custom-Header: NotSoCustom"
+    -H "Custom-Header: NotSoCustom" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
 ```
 
 ```javascript
@@ -244,8 +251,8 @@ Object.keys(params)
 let headers = {
     "Authorization": "customAuthToken",
     "Custom-Header": "NotSoCustom",
-    "Accept": "application/json",
     "Content-Type": "application/json",
+    "Accept": "application/json",
 };
 
 fetch(url, {
@@ -287,7 +294,9 @@ Parameter | Status | Description
 curl -X GET \
     -G "http://localhost/api/withAuthTag" \
     -H "Authorization: customAuthToken" \
-    -H "Custom-Header: NotSoCustom"
+    -H "Custom-Header: NotSoCustom" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
 ```
 
 ```javascript
@@ -298,8 +307,8 @@ const url = new URL(
 let headers = {
     "Authorization": "customAuthToken",
     "Custom-Header": "NotSoCustom",
-    "Accept": "application/json",
     "Content-Type": "application/json",
+    "Accept": "application/json",
 };
 
 fetch(url, {
@@ -331,7 +340,9 @@ null
 curl -X GET \
     -G "http://localhost/api/withEloquentApiResource" \
     -H "Authorization: customAuthToken" \
-    -H "Custom-Header: NotSoCustom"
+    -H "Custom-Header: NotSoCustom" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
 ```
 
 ```javascript
@@ -342,8 +353,8 @@ const url = new URL(
 let headers = {
     "Authorization": "customAuthToken",
     "Custom-Header": "NotSoCustom",
-    "Accept": "application/json",
     "Content-Type": "application/json",
+    "Accept": "application/json",
 };
 
 fetch(url, {
@@ -381,7 +392,9 @@ fetch(url, {
 curl -X POST \
     "http://localhost/api/withMultipleResponseTagsAndStatusCode" \
     -H "Authorization: customAuthToken" \
-    -H "Custom-Header: NotSoCustom"
+    -H "Custom-Header: NotSoCustom" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
 ```
 
 ```javascript
@@ -392,8 +405,8 @@ const url = new URL(
 let headers = {
     "Authorization": "customAuthToken",
     "Custom-Header": "NotSoCustom",
-    "Accept": "application/json",
     "Content-Type": "application/json",
+    "Accept": "application/json",
 };
 
 fetch(url, {
@@ -442,7 +455,9 @@ fetch(url, {
 curl -X GET \
     -G "http://localhost/api/withEloquentApiResourceCollectionClass" \
     -H "Authorization: customAuthToken" \
-    -H "Custom-Header: NotSoCustom"
+    -H "Custom-Header: NotSoCustom" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
 ```
 
 ```javascript
@@ -453,8 +468,8 @@ const url = new URL(
 let headers = {
     "Authorization": "customAuthToken",
     "Custom-Header": "NotSoCustom",
-    "Accept": "application/json",
     "Content-Type": "application/json",
+    "Accept": "application/json",
 };
 
 fetch(url, {
@@ -472,12 +487,7 @@ fetch(url, {
 {
     "data": [
         {
-            "id": 4,
-            "name": "Tested Again",
-            "email": "a@b.com"
-        },
-        {
-            "id": 4,
+            "id": 0,
             "name": "Tested Again",
             "email": "a@b.com"
         }
@@ -485,13 +495,6 @@ fetch(url, {
     "links": {
         "self": "link-value"
     }
-}
-```
-> Example response (500):
-
-```json
-{
-    "message": "Server Error"
 }
 ```
 
@@ -509,7 +512,9 @@ fetch(url, {
 curl -X GET \
     -G "http://localhost/api/echoesUrlParameters/4-consequatur/?something=consequatur" \
     -H "Authorization: customAuthToken" \
-    -H "Custom-Header: NotSoCustom"
+    -H "Custom-Header: NotSoCustom" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
 ```
 
 ```javascript
@@ -526,8 +531,8 @@ Object.keys(params)
 let headers = {
     "Authorization": "customAuthToken",
     "Custom-Header": "NotSoCustom",
-    "Accept": "application/json",
     "Content-Type": "application/json",
+    "Accept": "application/json",
 };
 
 fetch(url, {

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -37,7 +37,7 @@ class GenerateDocumentationTest extends TestCase
 
     public function tearDown(): void
     {
-        Utils::deleteDirectoryAndContents('/public/docs');
+  //      Utils::deleteDirectoryAndContents('/public/docs');
     }
 
     /**
@@ -196,6 +196,8 @@ class GenerateDocumentationTest extends TestCase
             'apidoc.routes.0.apply.headers' => [
                 'Authorization' => 'customAuthToken',
                 'Custom-Header' => 'NotSoCustom',
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
             ],
         ]);
         $this->artisan('apidoc:generate');
@@ -249,6 +251,8 @@ class GenerateDocumentationTest extends TestCase
             'apidoc.routes.0.apply.headers' => [
                 'Authorization' => 'customAuthToken',
                 'Custom-Header' => 'NotSoCustom',
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
             ],
         ]);
 

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -199,7 +199,7 @@ class GenerateDocumentationTest extends TestCase
                 'Custom-Header' => 'NotSoCustom',
             ],
         ]);
-        $this->artisan('apidoc:generate -v');
+        $this->artisan('apidoc:generate');
 
         $generatedMarkdown = __DIR__.'/../public/docs/source/index.md';
         $compareMarkdown = __DIR__.'/../public/docs/source/.compare.md';

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -856,10 +856,10 @@ abstract class GeneratorTestCase extends TestCase
             ],
             'response_calls' => [
                 'methods' => ['*'],
-                'query' => [
+                'queryParams' => [
                     'queryParam' => 'queryValue',
                 ],
-                'body' => [
+                'bodyParams' => [
                     'bodyParam' => 'bodyValue',
                 ],
             ],

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -647,12 +647,12 @@ abstract class GeneratorTestCase extends TestCase
         $route = $this->createRoute('POST', '/shouldFetchRouteResponse', 'shouldFetchRouteResponse', true);
 
         $rules = [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ],
             'response_calls' => [
                 'methods' => ['*'],
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                    'Accept' => 'application/json',
-                ],
             ],
         ];
         $parsed = $this->generator->processRoute($route, $rules);
@@ -849,13 +849,13 @@ abstract class GeneratorTestCase extends TestCase
         $route = $this->createRoute('PUT', '/echo/{id}', 'shouldFetchRouteResponseWithEchoedSettings', true);
 
         $rules = [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+                'header' => 'value',
+            ],
             'response_calls' => [
                 'methods' => ['*'],
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                    'Accept' => 'application/json',
-                    'header' => 'value',
-                ],
                 'query' => [
                     'queryParam' => 'queryValue',
                 ],
@@ -894,11 +894,11 @@ abstract class GeneratorTestCase extends TestCase
     {
         $route = $this->createRoute('GET', '/api/indexResource', 'index', true, TestResourceController::class);
         $rules = [
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
             'response_calls' => [
                 'methods' => ['*'],
-                'headers' => [
-                    'Accept' => 'application/json',
-                ],
             ],
         ];
 


### PR DESCRIPTION
- Removed `apply.response_calls.headers` in favour of `apply.headers`
- Renamed `response_calls.query` and `response_calls.body` to `response_calls.queryParams` and `response_calls.bodyParams`.