### PR TITLE
Miscellaneous changes to the generator

### DIFF
--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -318,3 +318,5 @@ If you don't specify an example response using any of the above means, this pack
 - You can set Laravel config variables. This is useful so you can prevent external services like notifications from being triggered. By default the `app.env` is set to 'documentation'. You can add more variables in the `config` key.
 
 - By default, the package will generate dummy values for your documented body and query parameters and send in the request. If you specified example values using `@bodyParam` or `@queryParam`, those will be used instead. You can configure additional parameters or overwrite the existing ones for the request in the `queryParams`, and `bodyParams` sections.
+
+- The `ResponseCalls` strategy will only attempt to fetch a response if there are no responses with a status code of 2xx already.

--- a/docs/generating-documentation.md
+++ b/docs/generating-documentation.md
@@ -48,11 +48,11 @@ php artisan apidoc:rebuild
  This will copy the views files to `\resources\views\vendor\apidoc`.
  
  - Next, create a file called {language-name}.blade.php (for example, ruby.blade.php) in the partials/example-requests directory. You can then write Markdown with Blade templating that describes how the example request for the language should be rendered. You have the `$route` variable available to you. This variable is an array with the following keys:
-    - `methods`: an array of the HTTP methods for that route
-    - `boundUri`: the complete URL for the route, with any url parameters replaced (/users/{id} -> /users/1)
-    - `headers`: key-value array of headers to be sent with route (according to your configuration)
-    - `cleanQueryParameters`: key-value array of query parameters with example values to be sent with the request. Parameters which have been excluded from the example requests (see [Example Parameters](documenting.html#example-parameters)) will not be present here.
-    - `cleanBodyParameters`: key-value array of body parameters with example values to be sent with the request. Parameters which have been excluded from the example requests (see [Example Parameters](documenting.html#example-parameters)) will not be present here.
+- `methods`: an array of the HTTP methods for that route
+- `boundUri`: the complete URL for the route, with any url parameters replaced (/users/{id} -> /users/1)
+- `headers`: key-value array of headers to be sent with route (according to your configuration)
+- `cleanQueryParameters`: key-value array of query parameters with example values to be sent with the request. Parameters which have been excluded from the example requests (see [Example Parameters](documenting.html#example-parameters)) will not be present here.
+- `cleanBodyParameters`: key-value array of body parameters with example values to be sent with the request. Parameters which have been excluded from the example requests (see [Example Parameters](documenting.html#example-parameters)) will not be present here.
 
 - Add the language to the `example_languages` array in the package config.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -142,9 +142,27 @@ Each strategy class must implement the __invoke method with the parameters as de
 - In the `bodyParameters` and `queryParameters` stages, you can return an array with arbitrary keys. These keys will serve as the names of your parameters. Array keys can be indicated with Laravel's dot notation. The value of each key should be an array with the following keys:
 
 ```
-'type', // Only used in bodyParameters
+'type', // Only valid in bodyParameters
 'description', 
 'required', // boolean
 'value', // An example value for the parameter
 ```
-- In the `responses` stage, your strategy should return an array containing the responses for different status codes. Each key in the array should be a HTTP status code, and each value should be a string containing the response.
+- In the `responses` stage, your strategy should return an array containing the responses for different status codes. Each item in the array should be an array representing the response with a `status` key containing the HTTP status code, and a `content` key a string containing the response. For example:
+
+```php
+
+    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionMethod $method, array $routeRules, array $context = [])
+    {
+        return [
+            [
+                'content' => "Haha",
+                'status' => 201
+            ],
+            [
+                'content' => "Nope",
+                'status' => 404
+            ],
+        ]
+    }
+```
+Responses are _additive_. This means all the responses returned from each stage are added together.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -165,4 +165,5 @@ Each strategy class must implement the __invoke method with the parameters as de
         ]
     }
 ```
-Responses are _additive_. This means all the responses returned from each stage are added together.
+
+Responses are _additive_. This means all the responses returned from each stage are added to the `responses` array. But note that the `ResponseCalls` strategy will only attempt to fetch a response if there are no responses with a status code of 2xx already.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4,6 +4,7 @@ You can use plugins to alter how the Generator fetches data about your routes. F
 ## The stages of route processing
 Route processing is performed in four stages:
 - metadata (this covers route `title`, route `description`, route `groupName`, route `groupDescription`, and authentication status (`authenticated`))
+- urlParameters
 - bodyParameters
 - queryParameters
 - responses
@@ -12,7 +13,7 @@ For each stage, the Generator attempts the specified strategies to fetch data. T
 
 There are a number of strategies inccluded with the package, so you don't have to set up anything to get it working.
 
-> Note: The included ResponseCalls strategy is designed to stop if a response has already been gotten from any other strategy.
+> Note: The included ResponseCalls strategy is designed to stop if a response with a 2xx status code has already been gotten via any other strategy.
 
 ## Strategies
 To create a strategy, create a class that extends `\Mpociot\ApiDoc\Strategies\Strategy`.

--- a/resources/views/documentarian.blade.php
+++ b/resources/views/documentarian.blade.php
@@ -8,7 +8,7 @@
 @foreach($parsedRoutes as $groupName => $routes)
 #{!! $groupName !!}
 {{-- We pick the first non-empty description we see. --}}
-{!! \Illuminate\Support\Arr::first($routes, function ($route) { return $route['groupDescription'] !== ''; })['groupDescription'] ?? '' !!}
+{!! \Illuminate\Support\Arr::first($routes, function ($route) { return $route['metadata']['groupDescription'] !== ''; })['metadata']['groupDescription'] ?? '' !!}
 @foreach($routes as $parsedRoute)
 @if($writeCompareFile === true)
 {!! $parsedRoute['output'] !!}

--- a/resources/views/partials/route.blade.php
+++ b/resources/views/partials/route.blade.php
@@ -17,8 +17,7 @@
 @endforeach
 
 @if(in_array('GET',$route['methods']) || (isset($route['showresponse']) && $route['showresponse']))
-@if(is_array($route['response']))
-@foreach($route['response'] as $response)
+@foreach($route['responses'] as $response)
 > Example response ({{$response['status']}}):
 
 ```json
@@ -29,17 +28,6 @@
 @endif
 ```
 @endforeach
-@else
-> Example response:
-
-```json
-@if(is_object($route['response']) || is_array($route['response']))
-{!! json_encode($route['response'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) !!}
-@else
-{!! json_encode(json_decode($route['response']), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) !!}
-@endif
-```
-@endif
 @endif
 
 ### HTTP Request

--- a/resources/views/partials/route.blade.php
+++ b/resources/views/partials/route.blade.php
@@ -1,12 +1,12 @@
 <!-- START_{{$route['id']}} -->
-@if($route['title'] != '')## {{ $route['title']}}
+@if($route['metadata']['title'] != '')## {{ $route['metadata']['title']}}
 @else## {{$route['uri']}}@endif
-@if($route['authenticated'])
+@if($route['metadata']['authenticated'])
 
 <br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>@endif
-@if($route['description'])
+@if($route['metadata']['description'])
 
-{!! $route['description'] !!}
+{!! $route['metadata']['description'] !!}
 @endif
 
 > Example request:

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -83,10 +83,10 @@ class GenerateDocumentation extends Command
         $generator = new Generator($this->docConfig);
         $parsedRoutes = $this->processRoutes($generator, $routes);
         $groupedRoutes = collect($parsedRoutes)
-            ->groupBy('groupName')
+            ->groupBy('metadata.groupName')
             ->sortBy(static function ($group) {
                 /* @var $group Collection */
-                return $group->first()['groupName'];
+                return $group->first()['metadata']['groupName'];
             }, SORT_NATURAL);
 
         $this->writeMarkdown($groupedRoutes);

--- a/src/Postman/CollectionWriter.php
+++ b/src/Postman/CollectionWriter.php
@@ -58,7 +58,7 @@ class CollectionWriter
                         $mode = $route['methods'][0] === 'PUT' ? 'urlencoded' : 'formdata';
 
                         return [
-                            'name' => $route['title'] != '' ? $route['title'] : url($route['uri']),
+                            'name' => $route['metadata']['title'] != '' ? $route['metadata']['title'] : url($route['uri']),
                             'request' => [
                                 'url' => url($route['uri']).(collect($route['queryParameters'])->isEmpty()
                                     ? ''
@@ -88,7 +88,7 @@ class CollectionWriter
                                         ];
                                     })->values()->toArray(),
                                 ],
-                                'description' => $route['description'],
+                                'description' => $route['metadata']['description'],
                                 'response' => [],
                             ],
                         ];

--- a/src/Strategies/Responses/ResponseCalls.php
+++ b/src/Strategies/Responses/ResponseCalls.php
@@ -47,9 +47,9 @@ class ResponseCalls extends Strategy
             $response = $this->makeApiCall($request);
             $response = [
                 [
-                'status' => $response->getStatusCode(),
-                'content' => $response->getContent()
-            ]
+                    'status' => $response->getStatusCode(),
+                    'content' => $response->getContent(),
+                ],
             ];
         } catch (\Exception $e) {
             echo 'Exception thrown during response call for ['.implode(',', $route->methods)."] {$route->uri}.\n";

--- a/src/Strategies/Responses/ResponseCalls.php
+++ b/src/Strategies/Responses/ResponseCalls.php
@@ -313,15 +313,18 @@ class ResponseCalls extends Strategy
      *
      * @return bool
      */
-    private function shouldMakeApiCall(Route $route, array $rulesToApply, array $context): bool
+    protected function shouldMakeApiCall(Route $route, array $rulesToApply, array $context): bool
     {
         $allowedMethods = $rulesToApply['methods'] ?? [];
         if (empty($allowedMethods)) {
             return false;
         }
 
-        if (! empty($context['responses'])) {
-            // Don't attempt a response call if there are already responses
+        // Don't attempt a response call if there are already successful responses
+        $successResponses = collect($context['responses'])->filter(function ($response) {
+            return ((string) $response['status'])[0] == '2';
+        })->count();
+        if ($successResponses) {
             return false;
         }
 

--- a/src/Strategies/Responses/ResponseCalls.php
+++ b/src/Strategies/Responses/ResponseCalls.php
@@ -45,7 +45,12 @@ class ResponseCalls extends Strategy
 
         try {
             $response = $this->makeApiCall($request);
-            $response = [$response->getStatusCode() => $response->getContent()];
+            $response = [
+                [
+                'status' => $response->getStatusCode(),
+                'content' => $response->getContent()
+            ]
+            ];
         } catch (\Exception $e) {
             echo 'Exception thrown during response call for ['.implode(',', $route->methods)."] {$route->uri}.\n";
             if (Flags::$shouldBeVerbose) {

--- a/src/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Strategies/Responses/UseApiResourceTags.php
@@ -3,6 +3,7 @@
 namespace Mpociot\ApiDoc\Strategies\Responses;
 
 use Exception;
+use Illuminate\Http\Response;
 use ReflectionClass;
 use ReflectionMethod;
 use Illuminate\Support\Arr;
@@ -79,10 +80,15 @@ class UseApiResourceTags extends Strategy
                     : $apiResourceClass::collection(collect($models));
             }
 
+            /** @var Response $response */
+            $response = response()->json(
+                $resource->toArray(app(Request::class))
+            );
             return [
-                $statusCode => response()
-                    ->json($resource->toArray(app(Request::class)))
-                    ->getContent(),
+                [
+                    'status' => $statusCode ?: $response->getStatusCode(),
+                    'content' => $response->getContent(),
+                ],
             ];
         } catch (\Exception $e) {
             echo 'Exception thrown when fetching Eloquent API resource response for ['.implode(',', $route->methods)."] {$route->uri}.\n";
@@ -105,7 +111,7 @@ class UseApiResourceTags extends Strategy
     {
         $content = $tag->getContent();
         preg_match('/^(\d{3})?\s?([\s\S]*)$/', $content, $result);
-        $status = $result[1] ?: 200;
+        $status = $result[1] ?: 0;
         $apiResourceClass = $result[2];
 
         return [$status, $apiResourceClass];

--- a/src/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Strategies/Responses/UseApiResourceTags.php
@@ -3,11 +3,11 @@
 namespace Mpociot\ApiDoc\Strategies\Responses;
 
 use Exception;
-use Illuminate\Http\Response;
 use ReflectionClass;
 use ReflectionMethod;
 use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
 use Mpociot\ApiDoc\Tools\Flags;
 use Mpociot\ApiDoc\Tools\Utils;
@@ -84,6 +84,7 @@ class UseApiResourceTags extends Strategy
             $response = response()->json(
                 $resource->toArray(app(Request::class))
             );
+
             return [
                 [
                     'status' => $statusCode ?: $response->getStatusCode(),

--- a/src/Strategies/Responses/UseResponseFileTag.php
+++ b/src/Strategies/Responses/UseResponseFileTag.php
@@ -60,10 +60,9 @@ class UseResponseFileTag extends Strategy
             $json = ! empty($result[3]) ? str_replace("'", '"', $result[3]) : '{}';
             $merged = array_merge(json_decode($content, true), json_decode($json, true));
 
-            return [json_encode($merged), (int) $status];
+            return ['content' => json_encode($merged), 'status' => (int) $status];
         }, $responseFileTags);
 
-        // Convert responses to [200 => 'response', 401 => 'response']
-        return collect($responses)->pluck('0', '1')->toArray();
+        return $responses;
     }
 }

--- a/src/Strategies/Responses/UseResponseTag.php
+++ b/src/Strategies/Responses/UseResponseTag.php
@@ -58,10 +58,10 @@ class UseResponseTag extends Strategy
             $status = $result[1] ?: 200;
             $content = $result[2] ?: '{}';
 
-            return [$content, (int) $status];
+            return ['content' => $content, 'status' => (int) $status];
         }, $responseTags);
 
         // Convert responses to [200 => 'response', 401 => 'response']
-        return collect($responses)->pluck('0', '1')->toArray();
+        return $responses;
     }
 }

--- a/src/Strategies/Responses/UseResponseTag.php
+++ b/src/Strategies/Responses/UseResponseTag.php
@@ -61,7 +61,6 @@ class UseResponseTag extends Strategy
             return ['content' => $content, 'status' => (int) $status];
         }, $responseTags);
 
-        // Convert responses to [200 => 'response', 401 => 'response']
         return $responses;
     }
 }

--- a/src/Strategies/Responses/UseTransformerTags.php
+++ b/src/Strategies/Responses/UseTransformerTags.php
@@ -73,9 +73,12 @@ class UseTransformerTags extends Strategy
                     new $transformer)
                 : new Item($modelInstance, new $transformer);
 
+            $response = response($fractal->createData($resource)->toJson());
             return [
-                $statusCode => response($fractal->createData($resource)->toJson())
-                    ->getContent(),
+                [
+                    'status' => $statusCode ?: $response->getStatusCode(),
+                    'content' => $response->getContent(),
+                ],
             ];
         } catch (\Exception $e) {
             echo 'Exception thrown when fetching transformer response for ['.implode(',', $route->methods)."] {$route->uri}.\n";

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -117,12 +117,7 @@ class Generator
     {
         $responses = $this->iterateThroughStrategies('responses', $context, [$route, $controller, $method, $rulesToApply]);
         if (count($responses)) {
-            return collect($responses)->map(function (string $response, int $status) {
-                return [
-                    'status' => $status ?: 200,
-                    'content' => $response,
-                ];
-            })->values()->toArray();
+            return $responses;
         }
 
         return null;
@@ -161,6 +156,11 @@ class Generator
             $results = $strategy(...$arguments);
             if (! is_null($results)) {
                 foreach ($results as $index => $item) {
+                    if ($stage == "responses") {
+                        // Responses are additive
+                        $context[$stage][] = $item;
+                        continue;
+                    }
                     // Using a for loop rather than array_merge or +=
                     // so it does not renumber numeric keys
                     // and also allows values to be overwritten

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -117,7 +117,9 @@ class Generator
     {
         $responses = $this->iterateThroughStrategies('responses', $context, [$route, $controller, $method, $rulesToApply]);
         if (count($responses)) {
-            return $responses;
+            return array_filter($responses, function ($response) {
+                return $response['content'] != null;
+            });
         }
 
         return null;
@@ -152,8 +154,9 @@ class Generator
         $context[$stage] = $context[$stage] ?? [];
         foreach ($strategies as $strategyClass) {
             $strategy = new $strategyClass($stage, $this->config);
-            $arguments[] = $context;
-            $results = $strategy(...$arguments);
+            $strategyArgs = $arguments;
+            $strategyArgs[] = $context;
+            $results = $strategy(...$strategyArgs);
             if (! is_null($results)) {
                 foreach ($results as $index => $item) {
                     if ($stage == "responses") {

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -80,8 +80,6 @@ class Generator
 
         $parsedRoute['headers'] = $routeRules['headers'] ?? [];
 
-        $parsedRoute += $metadata;
-
         return $parsedRoute;
     }
 

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -75,7 +75,7 @@ class Generator
         $parsedRoute['cleanBodyParameters'] = $this->cleanParams($bodyParameters);
 
         $responses = $this->fetchResponses($controller, $method, $route, $routeRules, $parsedRoute);
-        $parsedRoute['response'] = $responses;
+        $parsedRoute['responses'] = $responses;
         $parsedRoute['showresponse'] = ! empty($responses);
 
         $parsedRoute['headers'] = $routeRules['headers'] ?? [];

--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -157,7 +157,7 @@ class Generator
             $results = $strategy(...$strategyArgs);
             if (! is_null($results)) {
                 foreach ($results as $index => $item) {
-                    if ($stage == "responses") {
+                    if ($stage == 'responses') {
                         // Responses are additive
                         $context[$stage][] = $item;
                         continue;

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -260,6 +260,7 @@ class TestController extends Controller
     public function withResponseTag()
     {
         GeneratorTestCase::$globalValue = rand();
+
         return '';
     }
 

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -4,6 +4,7 @@ namespace Mpociot\ApiDoc\Tests\Fixtures;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Mpociot\ApiDoc\Tests\Unit\GeneratorTestCase;
 
 /**
  * @group Group A
@@ -258,6 +259,7 @@ class TestController extends Controller
      */
     public function withResponseTag()
     {
+        GeneratorTestCase::$globalValue = rand();
         return '';
     }
 

--- a/tests/Fixtures/index.md
+++ b/tests/Fixtures/index.md
@@ -61,11 +61,6 @@ fetch(url, {
 ```
 
 
-> Example response:
-
-```json
-null
-```
 
 ### HTTP Request
 `GET api/withDescription`
@@ -191,11 +186,6 @@ fetch(url, {
 ```
 
 
-> Example response:
-
-```json
-null
-```
 
 ### HTTP Request
 `GET api/withBodyParameters`
@@ -264,11 +254,6 @@ fetch(url, {
 ```
 
 
-> Example response:
-
-```json
-null
-```
 
 ### HTTP Request
 `GET api/withQueryParameters`
@@ -320,11 +305,6 @@ fetch(url, {
 ```
 
 
-> Example response:
-
-```json
-null
-```
 
 ### HTTP Request
 `GET api/withAuthTag`
@@ -370,11 +350,9 @@ fetch(url, {
 
 ```json
 {
-    "data": {
-        "id": 0,
-        "name": "Tested Again",
-        "email": "a@b.com"
-    }
+    "id": 4,
+    "name": "Tested Again",
+    "email": "a@b.com"
 }
 ```
 
@@ -487,7 +465,12 @@ fetch(url, {
 {
     "data": [
         {
-            "id": 0,
+            "id": 4,
+            "name": "Tested Again",
+            "email": "a@b.com"
+        },
+        {
+            "id": 4,
             "name": "Tested Again",
             "email": "a@b.com"
         }

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -37,7 +37,7 @@ class GenerateDocumentationTest extends TestCase
 
     public function tearDown(): void
     {
-        //      Utils::deleteDirectoryAndContents('/public/docs');
+             Utils::deleteDirectoryAndContents('/public/docs');
     }
 
     /**

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -37,7 +37,7 @@ class GenerateDocumentationTest extends TestCase
 
     public function tearDown(): void
     {
-             Utils::deleteDirectoryAndContents('/public/docs');
+        Utils::deleteDirectoryAndContents('/public/docs');
     }
 
     /**

--- a/tests/Unit/GeneratorPluginSystemTestCase.php
+++ b/tests/Unit/GeneratorPluginSystemTestCase.php
@@ -66,12 +66,12 @@ class GeneratorPluginSystemTestCase extends LaravelGeneratorTest
         $parsed = $generator->processRoute($route);
 
         $this->assertTrue($parsed['showresponse']);
-        $this->assertCount(2, $parsed['response']);
-        $first = array_shift($parsed['response']);
+        $this->assertCount(2, $parsed['responses']);
+        $first = array_shift($parsed['responses']);
         $this->assertTrue(is_array($first));
         $this->assertEquals(200, $first['status']);
         $this->assertEquals('dummy', $first['content']);
-        $second = array_shift($parsed['response']);
+        $second = array_shift($parsed['responses']);
         $this->assertTrue(is_array($second));
         $this->assertEquals(400, $second['status']);
         $this->assertEquals('dummy2', $second['content']);

--- a/tests/Unit/GeneratorPluginSystemTestCase.php
+++ b/tests/Unit/GeneratorPluginSystemTestCase.php
@@ -126,24 +126,8 @@ class GeneratorPluginSystemTestCase extends LaravelGeneratorTest
     }
 
     /** @test */
-    public function overwrites_results_from_previous_strategies_in_same_stage()
+    public function overwrites_metadat_from_previous_strategies_in_same_stage()
     {
-        $config = [
-            'strategies' => [
-                'responses' => [DummyResponseStrategy200::class, StillDummyResponseStrategyAlso200::class],
-            ],
-        ];
-        $route = $this->createRoute('GET', '/api/test', 'dummy', true, TestController::class);
-        $generator = new Generator(new DocumentationConfig($config));
-        $parsed = $generator->processRoute($route);
-
-        $this->assertTrue($parsed['showresponse']);
-        $this->assertCount(1, $parsed['response']);
-        $first = array_shift($parsed['response']);
-        $this->assertTrue(is_array($first));
-        $this->assertEquals(200, $first['status']);
-        $this->assertEquals('stilldummy', $first['content']);
-
         $config = [
             'strategies' => [
                 'metadata' => [NotDummyMetadataStrategy::class, PartialDummyMetadataStrategy1::class],
@@ -241,15 +225,7 @@ class DummyResponseStrategy200 extends Strategy
 {
     public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
     {
-        return [200 => 'dummy'];
-    }
-}
-
-class StillDummyResponseStrategyAlso200 extends Strategy
-{
-    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
-    {
-        return [200 => 'stilldummy'];
+        return [['status' => 200, 'content' => 'dummy']];
     }
 }
 
@@ -257,6 +233,6 @@ class DummyResponseStrategy400 extends Strategy
 {
     public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
     {
-        return [400 => 'dummy2'];
+        return [['status' => 400, 'content' => 'dummy2']];
     }
 }

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -11,7 +11,6 @@ use Mpociot\ApiDoc\Tests\Fixtures\TestUser;
 use Mpociot\ApiDoc\Tools\DocumentationConfig;
 use Mpociot\ApiDoc\Tests\Fixtures\TestController;
 use Mpociot\ApiDoc\ApiDocGeneratorServiceProvider;
-use Mpociot\ApiDoc\Tests\Fixtures\TestResourceController;
 
 abstract class GeneratorTestCase extends TestCase
 {

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -856,10 +856,10 @@ abstract class GeneratorTestCase extends TestCase
             ],
             'response_calls' => [
                 'methods' => ['*'],
-                'query' => [
+                'queryParams' => [
                     'queryParam' => 'queryValue',
                 ],
-                'body' => [
+                'bodyParams' => [
                     'bodyParam' => 'bodyValue',
                 ],
             ],

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -399,7 +399,7 @@ abstract class GeneratorTestCase extends TestCase
         $generator = new Generator(new DocumentationConfig($config));
         $parsed = $this->generator->processRoute($route);
 
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
         $this->assertTrue($parsed['showresponse']);
@@ -422,7 +422,7 @@ abstract class GeneratorTestCase extends TestCase
         $generator = new Generator(new DocumentationConfig($config));
         $parsed = $this->generator->processRoute($route);
 
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
         $this->assertTrue($parsed['showresponse']);
@@ -452,7 +452,7 @@ abstract class GeneratorTestCase extends TestCase
         $generator = new Generator(new DocumentationConfig($config));
         $parsed = $this->generator->processRoute($route);
 
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
         $this->assertTrue($parsed['showresponse']);
@@ -484,7 +484,7 @@ abstract class GeneratorTestCase extends TestCase
     {
         $route = $this->createRoute('POST', '/responseTag', 'withResponseTag');
         $parsed = $this->generator->processRoute($route);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -505,7 +505,7 @@ abstract class GeneratorTestCase extends TestCase
     {
         $route = $this->createRoute('POST', '/responseTag', 'withResponseTagAndStatusCode');
         $parsed = $this->generator->processRoute($route);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -526,20 +526,20 @@ abstract class GeneratorTestCase extends TestCase
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
         $this->assertTrue($parsed['showresponse']);
-        $this->assertTrue(is_array($parsed['response'][0]));
-        $this->assertEquals(200, $parsed['response'][0]['status']);
+        $this->assertTrue(is_array($parsed['responses'][0]));
+        $this->assertEquals(200, $parsed['responses'][0]['status']);
         $this->assertArraySubset([
             'id' => 4,
             'name' => 'banana',
             'color' => 'red',
             'weight' => '1 kg',
             'delicious' => true,
-        ], json_decode($parsed['response'][0]['content'], true));
-        $this->assertTrue(is_array($parsed['response'][1]));
-        $this->assertEquals(401, $parsed['response'][1]['status']);
+        ], json_decode($parsed['responses'][0]['content'], true));
+        $this->assertTrue(is_array($parsed['responses'][1]));
+        $this->assertEquals(401, $parsed['responses'][1]['status']);
         $this->assertArraySubset([
             'message' => 'Unauthorized',
-        ], json_decode($parsed['response'][1]['content'], true));
+        ], json_decode($parsed['responses'][1]['content'], true));
     }
 
     /**
@@ -554,7 +554,7 @@ abstract class GeneratorTestCase extends TestCase
         config(['apidoc.fractal.serializer' => $serializer]);
         $route = $this->createRoute('GET', '/transformerTag', 'transformerTag');
         $parsed = $this->generator->processRoute($route);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -572,7 +572,7 @@ abstract class GeneratorTestCase extends TestCase
     {
         $route = $this->createRoute('GET', '/transformerTagWithModel', 'transformerTagWithModel');
         $parsed = $this->generator->processRoute($route);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -590,7 +590,7 @@ abstract class GeneratorTestCase extends TestCase
     {
         $route = $this->createRoute('GET', '/transformerTagWithStatusCode', 'transformerTagWithStatusCode');
         $parsed = $this->generator->processRoute($route);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -608,7 +608,7 @@ abstract class GeneratorTestCase extends TestCase
     {
         $route = $this->createRoute('GET', '/transformerCollectionTag', 'transformerCollectionTag');
         $parsed = $this->generator->processRoute($route);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -627,7 +627,7 @@ abstract class GeneratorTestCase extends TestCase
     {
         $route = $this->createRoute('GET', '/transformerCollectionTagWithModel', 'transformerCollectionTagWithModel');
         $parsed = $this->generator->processRoute($route);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -656,7 +656,7 @@ abstract class GeneratorTestCase extends TestCase
             ],
         ];
         $parsed = $this->generator->processRoute($route, $rules);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -683,7 +683,7 @@ abstract class GeneratorTestCase extends TestCase
             ],
         ];
         $parsed = $this->generator->processRoute($route, $rules);
-        $response = json_decode(Arr::first($parsed['response'])['content'], true);
+        $response = json_decode(Arr::first($parsed['responses'])['content'], true);
         $originalValue = $response['app.env'];
 
         $now = time();
@@ -696,7 +696,7 @@ abstract class GeneratorTestCase extends TestCase
             ],
         ];
         $parsed = $this->generator->processRoute($route, $rules);
-        $response = json_decode(Arr::first($parsed['response'])['content'], true);
+        $response = json_decode(Arr::first($parsed['responses'])['content'], true);
         $newValue = $response['app.env'];
         $this->assertEquals($now, $newValue);
         $this->assertNotEquals($originalValue, $newValue);
@@ -712,7 +712,7 @@ abstract class GeneratorTestCase extends TestCase
             ],
         ];
         $parsed = $this->generator->processRoute($route, $rules);
-        $response = json_decode(Arr::first($parsed['response'])['content'], true);
+        $response = json_decode(Arr::first($parsed['responses'])['content'], true);
         $this->assertEquals(4, $response['param']);
     }
 
@@ -727,7 +727,7 @@ abstract class GeneratorTestCase extends TestCase
             ],
         ];
         $parsed = $this->generator->processRoute($route, $rules);
-        $response = json_decode(Arr::first($parsed['response'])['content'], true);
+        $response = json_decode(Arr::first($parsed['responses'])['content'], true);
         $this->assertEquals(4, $response['param']);
         $this->assertNotNull($response['param2']);
         $this->assertEquals(1, $response['param3']);
@@ -744,7 +744,7 @@ abstract class GeneratorTestCase extends TestCase
 
         $route = $this->createRoute('GET', '/responseFileTag', 'responseFileTag');
         $parsed = $this->generator->processRoute($route);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -769,7 +769,7 @@ abstract class GeneratorTestCase extends TestCase
 
         $route = $this->createRoute('GET', '/responseFileTagAndCustomJson', 'responseFileTagAndCustomJson');
         $parsed = $this->generator->processRoute($route);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
@@ -801,16 +801,16 @@ abstract class GeneratorTestCase extends TestCase
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);
         $this->assertTrue($parsed['showresponse']);
-        $this->assertTrue(is_array($parsed['response'][0]));
-        $this->assertEquals(200, $parsed['response'][0]['status']);
+        $this->assertTrue(is_array($parsed['responses'][0]));
+        $this->assertEquals(200, $parsed['responses'][0]['status']);
         $this->assertSame(
-            $parsed['response'][0]['content'],
+            $parsed['responses'][0]['content'],
             $successFixtureFileJson
         );
-        $this->assertTrue(is_array($parsed['response'][1]));
-        $this->assertEquals(401, $parsed['response'][1]['status']);
+        $this->assertTrue(is_array($parsed['responses'][1]));
+        $this->assertEquals(401, $parsed['responses'][1]['status']);
         $this->assertSame(
-            $parsed['response'][1]['content'],
+            $parsed['responses'][1]['content'],
             $errorFixtureFileJson
         );
 
@@ -865,7 +865,7 @@ abstract class GeneratorTestCase extends TestCase
             ],
         ];
         $parsed = $this->generator->processRoute($route, $rules);
-        $response = Arr::first($parsed['response']);
+        $response = Arr::first($parsed['responses']);
 
         $this->assertTrue(is_array($parsed));
         $this->assertArrayHasKey('showresponse', $parsed);

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -889,32 +889,6 @@ abstract class GeneratorTestCase extends TestCase
         $this->assertSame("This will be the long description.\nIt can also be multiple lines long.", $parsed['description']);
     }
 
-    /** @test */
-    public function combines_responses_from_different_strategies()
-    {
-        $route = $this->createRoute('GET', '/api/indexResource', 'index', true, TestResourceController::class);
-        $rules = [
-            'headers' => [
-                'Accept' => 'application/json',
-            ],
-            'response_calls' => [
-                'methods' => ['*'],
-            ],
-        ];
-
-        $parsed = $this->generator->processRoute($route, $rules);
-
-        $this->assertTrue(is_array($parsed));
-        $this->assertArrayHasKey('showresponse', $parsed);
-        $this->assertTrue($parsed['showresponse']);
-        $this->assertSame(1, count($parsed['response']));
-        $this->assertTrue(is_array($parsed['response'][0]));
-        $this->assertEquals(200, $parsed['response'][0]['status']);
-        $this->assertArraySubset([
-            'index_resource' => true,
-        ], json_decode($parsed['response'][0]['content'], true));
-    }
-
     abstract public function createRoute(string $httpMethod, string $path, string $controllerMethod, $register = false, $class = TestController::class);
 
     abstract public function createRouteUsesArray(string $httpMethod, string $path, string $controllerMethod, $register = false, $class = TestController::class);

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -24,11 +24,14 @@ abstract class GeneratorTestCase extends TestCase
             'metadata' => [
                 \Mpociot\ApiDoc\Strategies\Metadata\GetFromDocBlocks::class,
             ],
-            'bodyParameters' => [
-                \Mpociot\ApiDoc\Strategies\BodyParameters\GetFromBodyParamTag::class,
+            'urlParameters' => [
+                \Mpociot\ApiDoc\Strategies\UrlParameters\GetFromUrlParamTag::class,
             ],
             'queryParameters' => [
                 \Mpociot\ApiDoc\Strategies\QueryParameters\GetFromQueryParamTag::class,
+            ],
+            'bodyParameters' => [
+                \Mpociot\ApiDoc\Strategies\BodyParameters\GetFromBodyParamTag::class,
             ],
             'responses' => [
                 \Mpociot\ApiDoc\Strategies\Responses\UseResponseTag::class,
@@ -75,8 +78,8 @@ abstract class GeneratorTestCase extends TestCase
         $route = $this->createRoute('GET', '/api/test', 'withEndpointDescription');
         $parsed = $this->generator->processRoute($route);
 
-        $this->assertSame('Example title.', $parsed['title']);
-        $this->assertSame("This will be the long description.\nIt can also be multiple lines long.", $parsed['description']);
+        $this->assertSame('Example title.', $parsed['metadata']['title']);
+        $this->assertSame("This will be the long description.\nIt can also be multiple lines long.", $parsed['metadata']['description']);
     }
 
     /** @test */
@@ -326,7 +329,7 @@ abstract class GeneratorTestCase extends TestCase
     public function can_parse_route_group()
     {
         $route = $this->createRoute('GET', '/api/test', 'dummy');
-        $routeGroup = $this->generator->processRoute($route)['groupName'];
+        $routeGroup = $this->generator->processRoute($route)['metadata']['groupName'];
 
         $this->assertSame('Group A', $routeGroup);
     }
@@ -336,37 +339,37 @@ abstract class GeneratorTestCase extends TestCase
     {
         $route = $this->createRoute('GET', '/group/1', 'withGroupOverride');
         $parsedRoute = $this->generator->processRoute($route);
-        $this->assertSame('Group B', $parsedRoute['groupName']);
-        $this->assertSame('', $parsedRoute['groupDescription']);
+        $this->assertSame('Group B', $parsedRoute['metadata']['groupName']);
+        $this->assertSame('', $parsedRoute['metadata']['groupDescription']);
 
         $route = $this->createRoute('GET', '/group/2', 'withGroupOverride2');
         $parsedRoute = $this->generator->processRoute($route);
-        $this->assertSame('Group B', $parsedRoute['groupName']);
-        $this->assertSame('', $parsedRoute['groupDescription']);
-        $this->assertSame('This is also in Group B. No route description. Route title before gropp.', $parsedRoute['title']);
+        $this->assertSame('Group B', $parsedRoute['metadata']['groupName']);
+        $this->assertSame('', $parsedRoute['metadata']['groupDescription']);
+        $this->assertSame('This is also in Group B. No route description. Route title before gropp.', $parsedRoute['metadata']['title']);
 
         $route = $this->createRoute('GET', '/group/3', 'withGroupOverride3');
         $parsedRoute = $this->generator->processRoute($route);
-        $this->assertSame('Group B', $parsedRoute['groupName']);
-        $this->assertSame('', $parsedRoute['groupDescription']);
-        $this->assertSame('This is also in Group B. Route title after group.', $parsedRoute['title']);
+        $this->assertSame('Group B', $parsedRoute['metadata']['groupName']);
+        $this->assertSame('', $parsedRoute['metadata']['groupDescription']);
+        $this->assertSame('This is also in Group B. Route title after group.', $parsedRoute['metadata']['title']);
 
         $route = $this->createRoute('GET', '/group/4', 'withGroupOverride4');
         $parsedRoute = $this->generator->processRoute($route);
-        $this->assertSame('Group C', $parsedRoute['groupName']);
-        $this->assertSame('Group description after group.', $parsedRoute['groupDescription']);
-        $this->assertSame('This is in Group C. Route title before group.', $parsedRoute['title']);
+        $this->assertSame('Group C', $parsedRoute['metadata']['groupName']);
+        $this->assertSame('Group description after group.', $parsedRoute['metadata']['groupDescription']);
+        $this->assertSame('This is in Group C. Route title before group.', $parsedRoute['metadata']['title']);
     }
 
     /** @test */
     public function can_parse_auth_tags()
     {
         $route = $this->createRoute('GET', '/api/test', 'withAuthenticatedTag');
-        $authenticated = $this->generator->processRoute($route)['authenticated'];
+        $authenticated = $this->generator->processRoute($route)['metadata']['authenticated'];
         $this->assertTrue($authenticated);
 
         $route = $this->createRoute('GET', '/api/test', 'dummy');
-        $authenticated = $this->generator->processRoute($route)['authenticated'];
+        $authenticated = $this->generator->processRoute($route)['metadata']['authenticated'];
         $this->assertFalse($authenticated);
     }
 
@@ -932,8 +935,8 @@ abstract class GeneratorTestCase extends TestCase
 
         $parsed = $this->generator->processRoute($route);
 
-        $this->assertSame('Example title.', $parsed['title']);
-        $this->assertSame("This will be the long description.\nIt can also be multiple lines long.", $parsed['description']);
+        $this->assertSame('Example title.', $parsed['metadata']['title']);
+        $this->assertSame("This will be the long description.\nIt can also be multiple lines long.", $parsed['metadata']['description']);
     }
 
     abstract public function createRoute(string $httpMethod, string $path, string $controllerMethod, $register = false, $class = TestController::class);


### PR DESCRIPTION
- Moved `groupName`, `groupDescription`, `title`, `description`, and `authenticated` into parsed route `metadata`.
- Renamed parsed route's `response` to `responses`.
- Made ResponseCalls strategy only execute if no successful responses exist.
- Hide null responses in examples.
- Made `responses` stage additive