### PR TITLE
Add 4.x-dev branch alias for the v4 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
             "providers": [
                 "Mpociot\\ApiDoc\\ApiDocGeneratorServiceProvider"
             ]
-       }
+        },
+        "branch-alias": {
+            "dev-v4": "4.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This allows you to install the package with a `4.x-dev` constraint, which can easily move to a more stable branch (e.g. master) once development of the new version has matured. https://getcomposer.org/doc/articles/aliases.md#branch-alias