### PR TITLE
Use single quotes in PHP example template and mention how to customise them

### DIFF
--- a/docs/generating-documentation.md
+++ b/docs/generating-documentation.md
@@ -58,6 +58,8 @@ php artisan apidoc:rebuild
 
 - Generate your documentation 
 
+To customise existing language templates you can perform the `vendor:publish` command above, then modify the blade templates in `resources/` as necessary.
+
 ## Further modification
 
 This package uses [Documentarian](https://github.com/mpociot/documentarian) to generate the API documentation. If you want to modify the CSS files of your documentation, or simply want to learn more about what is possible, take a look at the [Documentarian guide](http://marcelpociot.de/documentarian/installation).

--- a/resources/views/partials/example-requests/php.blade.php
+++ b/resources/views/partials/example-requests/php.blade.php
@@ -2,7 +2,7 @@
 
 $client = new \GuzzleHttp\Client();
 $response = $client->{{ strtolower($route['methods'][0]) }}(
-  "{{ rtrim($baseUrl, '/') . '/' . ltrim($route['boundUri'], '/') }}",
+  '{{ rtrim($baseUrl, '/') . '/' . ltrim($route['boundUri'], '/') }}',
   [
 @if(!empty($route['headers']))
     'headers' => {!! \Mpociot\ApiDoc\Tools\Utils::printPhpValue($route['headers'], 4) !!},
@@ -10,7 +10,7 @@ $response = $client->{{ strtolower($route['methods'][0]) }}(
 @if(!empty($route['cleanQueryParameters']))
     'query' => [
 @foreach($route['cleanQueryParameters'] as $parameter => $value)
-      "{{$parameter}}" => "{{$value}}",
+      '{{$parameter}}' => '{{$value}}',
 @endforeach
     ],
 @endif


### PR DESCRIPTION
Existing language templates may be customised by performing the same steps as you would to add new language examples. I've added a note to the docs mentioning that.

This also switches the double quotes in the PHP example template for single quotes, which are used in the `var_export()` examples - so it's more consistent.

There's an inconsistency still between short and long array syntax - `var_export()` uses long syntax. We could use [symfony/var-exporter](https://github.com/symfony/var-exporter) as a replacement in `Utils::printPhpValue()`, but I haven't done that in this PR because I'm not sure adding another dependency (which isn't in Laravel by default) just for this is worthwhile.