### PR TITLE
Use symfony/var-exporter to export PHP arrays, ensuring short array syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "mpociot/documentarian": "^0.3.0",
         "mpociot/reflection-docblock": "^1.0.1",
         "ramsey/uuid": "^3.8",
+        "symfony/var-exporter": "^4.0",
         "league/flysystem": "^1.0",
         "nunomaduro/collision": "^3.0"
     },

--- a/src/Tools/Utils.php
+++ b/src/Tools/Utils.php
@@ -5,6 +5,7 @@ namespace Mpociot\ApiDoc\Tools;
 use Illuminate\Routing\Route;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Adapter\Local;
+use Symfony\Component\VarExporter\VarExporter;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -95,7 +96,7 @@ class Utils
 
     public static function printPhpValue($value, $indentationLevel = 0)
     {
-        $output = var_export($value, true);
+        $output = VarExporter::export($value);
         // Padding with x spaces so they align
         $split = explode("\n", $output);
         $result = '';


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/5170590/67124464-67834780-f1a7-11e9-8e5b-a05e51a22b6b.png)
