### PR TITLE
Authentication required can now be configured at a global default level

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -202,6 +202,12 @@ return [
     'default_group' => 'general',
 
     /*
+     * Whether authentication is required for your API endpoints by default. Note that if you enable
+     * this you can still opt out for individual methods by adding @unauthenticated to your docblock.
+     */
+    'default_authenticated' => false,
+
+    /*
      * Example requests for each endpoint will be shown in each of these languages.
      * Supported options are: bash, javascript, php, python
      * You can add a language of your own, but you must publish the package's views

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -149,7 +149,12 @@ public function createPost(MyRequest $request)
 ```
 
 ## Indicating authentication status
-You can use the `@authenticated` annotation on a method to indicate if the endpoint is authenticated. A "Requires authentication" badge will be added to that route in the generated documentation.
+You can use the `@authenticated` annotation on a method to indicate if the endpoint is authenticated. A
+"Requires authentication" badge will be added to that route in the generated documentation.
+
+You can also enable authentication for your API documentation by default by setting `'default_authentication' => true`
+in your config file. Individual endpoints can have authentication disabled individually by using the
+`@unauthenticated` annotation in this case.
 
 ## Providing an example response
 You can provide an example response for a route. This will be displayed in the examples section. There are several ways of doing this.

--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -92,7 +92,7 @@ class Generator
             'groupDescription' => '',
             'title' => '',
             'description' => '',
-            'authenticated' => false,
+            'authenticated' => $this->config->get('default_authenticated', false),
         ];
 
         return $this->iterateThroughStrategies('metadata', $context, [$route, $controller, $method, $rulesToApply]);

--- a/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
+++ b/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
@@ -32,10 +32,20 @@ class GetFromDocBlocks extends Strategy
     /**
      * @param array $tags Tags in the method doc block
      *
-     * @return bool
+     * @return bool Whether authentication is required
      */
     protected function getAuthStatusFromDocBlock(array $tags)
     {
+        if ($this->config->get('default_authenticated', false)) {
+            // If global default is that all endpoints require authentication, allow @unauthenticated to negate tis
+            $unAuthTag = collect($tags)
+                ->first(function ($tag) {
+                    return $tag instanceof Tag && strtolower($tag->getName()) === 'unauthenticated';
+                });
+
+            return ! $unAuthTag;
+        }
+
         $authTag = collect($tags)
             ->first(function ($tag) {
                 return $tag instanceof Tag && strtolower($tag->getName()) === 'authenticated';

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -138,6 +138,14 @@ class TestController extends Controller
     }
 
     /**
+     * @unauthenticated
+     */
+    public function withUnauthenticatedTag()
+    {
+        return '';
+    }
+
+    /**
      * @apiResource \Mpociot\ApiDoc\Tests\Fixtures\TestUserApiResource
      * @apiResourceModel \Mpociot\ApiDoc\Tests\Fixtures\TestUser
      */

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -41,6 +41,7 @@ abstract class GeneratorTestCase extends TestCase
             ],
         ],
         'default_group' => 'general',
+        'default_authenticated' => false,
     ];
 
     public static $globalValue = null;
@@ -370,6 +371,31 @@ abstract class GeneratorTestCase extends TestCase
         $route = $this->createRoute('GET', '/api/test', 'dummy');
         $authenticated = $this->generator->processRoute($route)['metadata']['authenticated'];
         $this->assertFalse($authenticated);
+    }
+
+    /**
+     * @test
+     * @dataProvider unauthenticatedProvider
+     */
+    public function can_parse_unauthenticed_tags_when_global_authenticated_is_enabled($method, $setting, $expected)
+    {
+        $route = $this->createRoute('GET', '/api/test', $method);
+
+        $config = $this->config;
+        $config['default_authenticated'] = $setting;
+        $generator = new Generator(new DocumentationConfig($config));
+
+        $authenticated = $generator->processRoute($route)['metadata']['authenticated'];
+        $this->assertSame($expected, $authenticated);
+    }
+
+    public function unauthenticatedProvider()
+    {
+        return [
+            'authenticated default' => ['dummy', true, true],
+            'authenticated default with unauthenticated opt out' => ['withUnauthenticatedTag', true, false],
+            'unauthenticated tag ignored without default authenticated' => ['withUnauthenticatedTag', false, false],
+        ];
     }
 
     /** @test */


### PR DESCRIPTION
When `default_authenticated => true` is enabled in configuration, all endpoints will be tagged as requiring authentication. You can opt out of this for specific endpoints by using `@unauthenticated` in the same way as you would usually opt-in with the `@authenticated` tag.

Resolves https://github.com/mpociot/laravel-apidoc-generator/issues/618