### PR TITLE
Transformer annotations are now given priority over response annotations

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -176,10 +176,10 @@ return [
             \Mpociot\ApiDoc\Extracting\Strategies\BodyParameters\GetFromBodyParamTag::class,
         ],
         'responses' => [
+            \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseResponseTag::class,
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseResponseFileTag::class,
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseApiResourceTags::class,
-            \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\ResponseCalls::class,
         ],
     ],

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -67,10 +67,10 @@ The last thing to do is to register the strategy. Strategies are registered in a
             \Mpociot\ApiDoc\Extracting\Strategies\BodyParameters\GetFromBodyParamTag::class,
         ],
         'responses' => [
+            \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseResponseTag::class,
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseResponseFileTag::class,
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseApiResourceTags::class,
-            \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\ResponseCalls::class,
         ],
     ],

--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -141,10 +141,10 @@ class Generator
                 \Mpociot\ApiDoc\Extracting\Strategies\BodyParameters\GetFromBodyParamTag::class,
             ],
             'responses' => [
+                \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,
                 \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseResponseTag::class,
                 \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseResponseFileTag::class,
                 \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseApiResourceTags::class,
-                \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,
                 \Mpociot\ApiDoc\Extracting\Strategies\Responses\ResponseCalls::class,
             ],
         ];

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -33,10 +33,10 @@ abstract class GeneratorTestCase extends TestCase
                 \Mpociot\ApiDoc\Extracting\Strategies\BodyParameters\GetFromBodyParamTag::class,
             ],
             'responses' => [
+                \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,
                 \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseResponseTag::class,
                 \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseResponseFileTag::class,
                 \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseApiResourceTags::class,
-                \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,
                 \Mpociot\ApiDoc\Extracting\Strategies\Responses\ResponseCalls::class,
             ],
         ],


### PR DESCRIPTION
This may be an opinionated change, but given that transformer annotations describe 200 responses, I think that they should be shown before any other response annotations (e.g. 404 or 402s).

This change moves it up the list of strategies to give it priority over the response strategies.