### PR TITLE
Fix indentation in PHP example template, now uses 4 spaces consistently

### DIFF
--- a/resources/views/partials/example-requests/php.blade.php
+++ b/resources/views/partials/example-requests/php.blade.php
@@ -2,22 +2,22 @@
 
 $client = new \GuzzleHttp\Client();
 $response = $client->{{ strtolower($route['methods'][0]) }}(
-  '{{ rtrim($baseUrl, '/') . '/' . ltrim($route['boundUri'], '/') }}',
-  [
+    '{{ rtrim($baseUrl, '/') . '/' . ltrim($route['boundUri'], '/') }}',
+    [
 @if(!empty($route['headers']))
-    'headers' => {!! \Mpociot\ApiDoc\Tools\Utils::printPhpValue($route['headers'], 4) !!},
+        'headers' => {!! \Mpociot\ApiDoc\Tools\Utils::printPhpValue($route['headers'], 8) !!},
 @endif
 @if(!empty($route['cleanQueryParameters']))
-    'query' => [
+        'query' => [
 @foreach($route['cleanQueryParameters'] as $parameter => $value)
-      '{{$parameter}}' => '{{$value}}',
+            '{{$parameter}}' => '{{$value}}',
 @endforeach
-    ],
+        ],
 @endif
 @if(!empty($route['cleanBodyParameters']))
-    'json' => {!! \Mpociot\ApiDoc\Tools\Utils::printPhpValue($route['cleanBodyParameters'], 4) !!},
+        'json' => {!! \Mpociot\ApiDoc\Tools\Utils::printPhpValue($route['cleanBodyParameters'], 8) !!},
 @endif
-  ]
+    ]
 );
 $body = $response->getBody();
 print_r(json_decode((string) $body));


### PR DESCRIPTION
Fixes #621

Before:

![image](https://user-images.githubusercontent.com/5170590/68042325-d70d3280-fc8f-11e9-88f6-775cbbc7089a.png)
![image](https://user-images.githubusercontent.com/5170590/68042290-c361cc00-fc8f-11e9-9ac9-d5294f88e3a5.png)


After:

![image](https://user-images.githubusercontent.com/5170590/68042203-92819700-fc8f-11e9-9ed7-bb117d13337b.png)
![image](https://user-images.githubusercontent.com/5170590/68042220-a1684980-fc8f-11e9-942e-e177c6f540e8.png)
