### PR TITLE
[Issue 637] Fix bash example generation for arrays on @queryParam or @bodyParam

### DIFF
--- a/resources/views/partials/example-requests/bash.blade.php
+++ b/resources/views/partials/example-requests/bash.blade.php
@@ -1,7 +1,11 @@
 ```bash
 curl -X {{$route['methods'][0]}} \
-    {{$route['methods'][0] == 'GET' ? '-G ' : ''}}"{{ rtrim($baseUrl, '/')}}/{{ ltrim($route['boundUri'], '/') }}@if(count($route['cleanQueryParameters']))?@foreach($route['cleanQueryParameters'] as $parameter => $value)
-{{ urlencode($parameter) }}={{ urlencode($value) }}@if(!$loop->last)&@endif
+{{$route['methods'][0] == 'GET' ? '-G ' : ''}}"{{ rtrim($baseUrl, '/')}}/{{ ltrim($route['boundUri'], '/') }}@if(count($route['cleanQueryParameters']))?@foreach($route['cleanQueryParameters'] as $parameter => $value)
+    @if (is_array($value))
+        {{ urlencode($parameter) }}[]={{ urlencode(array_keys($value)[0]) }}@if(! $loop->last)&@endif
+    @else
+        {{ urlencode($parameter) }}={{ urlencode($value) }}@if(!$loop->last)&@endif
+    @endif
 @endforeach
 @endif" @if(count($route['headers']))\
 @foreach($route['headers'] as $header => $value)


### PR DESCRIPTION
Picks up on solution discussed at https://github.com/mpociot/laravel-apidoc-generator/issues/637 
There is an error in the proposed solution, so I fixed it and hope we can integrate this bugfix back into your repo.