### PR TITLE
Expanding Postman collection support

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -41,6 +41,12 @@ return [
          * The description for the exported Postman collection.
          */
         'description' => null,
+
+        /*
+         * The "Auth" section that should appear in the postman collection. See the schema docs for more information:
+         * https://schema.getpostman.com/json/collection/v2.0.0/docs/index.html
+         */
+        'auth' => null,
     ],
 
     /*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
     ignoreErrors:
         - '#Call to an undefined static method Illuminate\\Support\\Facades\\Route::getRoutes().#'
         - '#Call to an undefined static method Illuminate\\Support\\Facades\\URL::forceRootUrl()#'
-        - '#Call to an undefined static method Illuminate\\Support\\Facades\\URL::forceScheme()#'
+        - '#Call to an undefined static method Illuminate\\Support\\Facades\\URL::formatRoot()#'
         - '#Cannot access offset .+ on Illuminate\\Contracts\\Foundation\\Application.#'
         - '#Call to an undefined method Illuminate\\Routing\\Route::versions().#'
         - '#(.*)NunoMaduro\\Collision(.*)#'

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -131,7 +131,7 @@ class PostmanCollectionWriter
             'query' => $queryParams->union($route['queryParameters'])->map(function ($parameter, $key) {
                 return [
                     'key' => $key,
-                    'value' => $parameter['value'],
+                    'value' => urlencode($parameter['value']),
                     'description' => $parameter['description'],
                     // Default query params to disabled if they aren't required and have empty values
                     'disabled' => ! $parameter['required'] && empty($parameter['value']),
@@ -149,7 +149,7 @@ class PostmanCollectionWriter
             return [
                 'id' => $key,
                 'key' => $key,
-                'value' => $parameter['value'],
+                'value' => urlencode($parameter['value']),
                 'description' => $parameter['description'],
             ];
         })->values()->toArray();

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -61,8 +61,7 @@ class PostmanCollectionWriter
             })->values()->toArray(),
         ];
 
-
-        if (!empty($this->auth)) {
+        if (! empty($this->auth)) {
             $collection['auth'] = $this->auth;
         }
 
@@ -74,6 +73,7 @@ class PostmanCollectionWriter
         $mode = 'raw';
 
         $method = $route['methods'][0];
+
         return [
             'name' => $route['metadata']['title'] != '' ? $route['metadata']['title'] : $route['uri'],
             'request' => [
@@ -96,7 +96,7 @@ class PostmanCollectionWriter
 
         // Exclude authentication headers if they're handled by Postman auth
         $authHeader = $this->getAuthHeader();
-        if (!empty($authHeader)) {
+        if (! empty($authHeader)) {
             $headers = $headers->except($authHeader);
         }
 
@@ -116,8 +116,8 @@ class PostmanCollectionWriter
 
     protected function makeUrlData($route)
     {
-        [$urlParams, $queryParams] = collect($route['urlParameters'])->partition(function($_, $key) use ($route) {
-            return Str::contains($route['uri'], '{' . $key . '}');
+        [$urlParams, $queryParams] = collect($route['urlParameters'])->partition(function ($_, $key) use ($route) {
+            return Str::contains($route['uri'], '{'.$key.'}');
         });
 
         /** @var Collection $queryParams */
@@ -126,7 +126,7 @@ class PostmanCollectionWriter
             'host' => $this->baseUrl,
             // Substitute laravel/symfony query params ({example}) to Postman style, prefixed with a colon
             'path' => preg_replace_callback('/\/{(\w+)\??}(?=\/|$)/', function ($matches) {
-                return '/:' . $matches[1];
+                return '/:'.$matches[1];
             }, $route['uri']),
             'query' => $queryParams->union($route['queryParameters'])->map(function ($parameter, $key) {
                 return [
@@ -134,7 +134,7 @@ class PostmanCollectionWriter
                     'value' => $parameter['value'],
                     'description' => $parameter['description'],
                     // Default query params to disabled if they aren't required and have empty values
-                    'disabled' => !$parameter['required'] && empty($parameter['value']),
+                    'disabled' => ! $parameter['required'] && empty($parameter['value']),
                 ];
             })->values()->toArray(),
         ];
@@ -160,7 +160,7 @@ class PostmanCollectionWriter
     protected function getAuthHeader()
     {
         $auth = $this->auth;
-        if (empty($auth) || !is_string($auth['type'] ?? null)) {
+        if (empty($auth) || ! is_string($auth['type'] ?? null)) {
             return null;
         }
 

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -117,8 +117,8 @@ class PostmanCollectionWriter
     protected function makeUrlData($route)
     {
         // URL Parameters are collected by the `UrlParameters` strategies, but only make sense if they're in the route
-        // definition. Filter out any URL parameters that don't appear in the URL, and assume they're query params.
-        [$urlParams, $queryParams] = collect($route['urlParameters'])->partition(function ($_, $key) use ($route) {
+        // definition. Filter out any URL parameters that don't appear in the URL.
+        $urlParams = collect($route['urlParameters'])->filter(function ($_, $key) use ($route) {
             return Str::contains($route['uri'], '{'.$key.'}');
         });
 
@@ -130,7 +130,7 @@ class PostmanCollectionWriter
             'path' => preg_replace_callback('/\/{(\w+)\??}(?=\/|$)/', function ($matches) {
                 return '/:'.$matches[1];
             }, $route['uri']),
-            'query' => $queryParams->union($route['queryParameters'])->map(function ($parameter, $key) {
+            'query' => collect($route['queryParameters'])->map(function ($parameter, $key) {
                 return [
                     'key' => $key,
                     'value' => urlencode($parameter['value']),

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -116,6 +116,8 @@ class PostmanCollectionWriter
 
     protected function makeUrlData($route)
     {
+        // URL Parameters are collected by the `UrlParameters` strategies, but only make sense if they're in the route
+        // definition. Filter out any URL parameters that don't appear in the URL, and assume they're query params.
         [$urlParams, $queryParams] = collect($route['urlParameters'])->partition(function ($_, $key) use ($route) {
             return Str::contains($route['uri'], '{'.$key.'}');
         });

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -223,7 +223,11 @@ class Writer
      */
     public function generatePostmanCollection(Collection $routes)
     {
-        $writer = new PostmanCollectionWriter($routes, $this->baseUrl);
+        /** @var PostmanCollectionWriter $writer */
+        $writer = app()->makeWith(
+            PostmanCollectionWriter::class,
+            ['routeGroups' => $routes, 'baseUrl' => $this->baseUrl]
+        );
 
         return $writer->getCollection();
     }

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -14,7 +14,12 @@
                 {
                     "name": "Example title.",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withDescription",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withDescription",
+                            "query": []
+                        },
                         "method": "GET",
                         "header": [
                             {
@@ -43,9 +48,14 @@
                     }
                 },
                 {
-                    "name": "http:\/\/localhost\/api\/withResponseTag",
+                    "name": "api\/withResponseTag",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withResponseTag",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withResponseTag",
+                            "query": []
+                        },
                         "method": "GET",
                         "header": [
                             {
@@ -76,7 +86,12 @@
                 {
                     "name": "Endpoint with body parameters.",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withBodyParameters",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withBodyParameters",
+                            "query": []
+                        },
                         "method": "POST",
                         "header": [
                             {
@@ -105,9 +120,45 @@
                     }
                 },
                 {
-                    "name": "http:\/\/localhost\/api\/withQueryParameters",
+                    "name": "api\/withQueryParameters",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withQueryParameters?location_id=consequatur&user_id=me&page=4&filters=consequatur&url_encoded=%2B+%5B%5D%26%3D",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withQueryParameters",
+                            "query": [
+                                {
+                                    "key": "location_id",
+                                    "value": "consequatur",
+                                    "description": "The id of the location.",
+                                    "disabled": false
+                                },
+                                {
+                                    "key": "user_id",
+                                    "value": "me",
+                                    "description": "The id of the user.",
+                                    "disabled": false
+                                },
+                                {
+                                    "key": "page",
+                                    "value": "4",
+                                    "description": "The page number.",
+                                    "disabled": false
+                                },
+                                {
+                                    "key": "filters",
+                                    "value": "consequatur",
+                                    "description": "The filters.",
+                                    "disabled": false
+                                },
+                                {
+                                    "key": "url_encoded",
+                                    "value": "%2B+%5B%5D%26%3D",
+                                    "description": "Used for testing that URL parameters will be URL-encoded where needed.",
+                                    "disabled": false
+                                }
+                            ]
+                        },
                         "method": "GET",
                         "header": [
                             {
@@ -136,9 +187,14 @@
                     }
                 },
                 {
-                    "name": "http:\/\/localhost\/api\/withAuthTag",
+                    "name": "api\/withAuthTag",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withAuthTag",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withAuthTag",
+                            "query": []
+                        },
                         "method": "GET",
                         "header": [
                             {
@@ -167,9 +223,14 @@
                     }
                 },
                 {
-                    "name": "http:\/\/localhost\/api\/withEloquentApiResource",
+                    "name": "api\/withEloquentApiResource",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withEloquentApiResource",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withEloquentApiResource",
+                            "query": []
+                        },
                         "method": "GET",
                         "header": [
                             {
@@ -198,9 +259,14 @@
                     }
                 },
                 {
-                    "name": "http:\/\/localhost\/api\/withMultipleResponseTagsAndStatusCode",
+                    "name": "api\/withMultipleResponseTagsAndStatusCode",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withMultipleResponseTagsAndStatusCode",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withMultipleResponseTagsAndStatusCode",
+                            "query": []
+                        },
                         "method": "POST",
                         "header": [
                             {
@@ -235,9 +301,14 @@
             "description": "",
             "item": [
                 {
-                    "name": "http:\/\/localhost\/api\/withEloquentApiResourceCollectionClass",
+                    "name": "api\/withEloquentApiResourceCollectionClass",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withEloquentApiResourceCollectionClass",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withEloquentApiResourceCollectionClass",
+                            "query": []
+                        },
                         "method": "GET",
                         "header": [
                             {
@@ -266,9 +337,41 @@
                     }
                 },
                 {
-                    "name": "http:\/\/localhost\/api\/echoesUrlParameters\/{param}-{param2}\/{param3?}",
+                    "name": "api\/echoesUrlParameters\/{param}-{param2}\/{param3?}",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/echoesUrlParameters\/{param}-{param2}\/{param3?}?something=consequatur",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/echoesUrlParameters\/{param}-{param2}\/:param3",
+                            "query": [
+                                {
+                                    "key": "param4",
+                                    "value": "",
+                                    "description": "",
+                                    "disabled": true
+                                },
+                                {
+                                    "key": "something",
+                                    "value": "consequatur",
+                                    "description": "",
+                                    "disabled": false
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "id": "param",
+                                    "key": "param",
+                                    "value": "4",
+                                    "description": ""
+                                },
+                                {
+                                    "id": "param2",
+                                    "key": "param2",
+                                    "value": "consequatur",
+                                    "description": ""
+                                }
+                            ]
+                        },
                         "method": "GET",
                         "header": [
                             {

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -345,12 +345,6 @@
                             "path": "api\/echoesUrlParameters\/{param}-{param2}\/:param3",
                             "query": [
                                 {
-                                    "key": "param4",
-                                    "value": "",
-                                    "description": "",
-                                    "disabled": true
-                                },
-                                {
                                     "key": "something",
                                     "value": "consequatur",
                                     "description": "",

--- a/tests/Fixtures/collection_custom_url.json
+++ b/tests/Fixtures/collection_custom_url.json
@@ -14,7 +14,12 @@
                 {
                     "name": "Example title.",
                     "request": {
-                        "url": "http:\/\/yourapp.app\/api\/test",
+                        "url": {
+                            "protocol": "http",
+                            "host": "yourapp.app",
+                            "path": "api/test",
+                            "query": []
+                        },
                         "method": "GET",
                         "header": [
                             {
@@ -35,9 +40,14 @@
                     }
                 },
                 {
-                    "name": "http:\/\/yourapp.app\/api\/responseTag",
+                    "name": "api\/responseTag",
                     "request": {
-                        "url": "http:\/\/yourapp.app\/api\/responseTag",
+                        "url": {
+                            "protocol": "http",
+                            "host": "yourapp.app",
+                            "path": "api/responseTag",
+                            "query": []
+                        },
                         "method": "POST",
                         "header": [
                             {

--- a/tests/Fixtures/collection_with_body_parameters.json
+++ b/tests/Fixtures/collection_with_body_parameters.json
@@ -14,7 +14,12 @@
                 {
                     "name": "Endpoint with body parameters.",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withBodyParameters",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withBodyParameters",
+                            "query": []
+                        },
                         "method": "GET",
                         "header": [
                             {

--- a/tests/Fixtures/collection_with_custom_headers.json
+++ b/tests/Fixtures/collection_with_custom_headers.json
@@ -12,9 +12,14 @@
             "description": "",
             "item": [
                 {
-                    "name": "http:\/\/localhost\/api\/headers",
+                    "name": "api\/headers",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/headers",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api/headers",
+                            "query": []
+                        },
                         "method": "GET",
                         "header": [
                             {

--- a/tests/Fixtures/collection_with_query_parameters.json
+++ b/tests/Fixtures/collection_with_query_parameters.json
@@ -12,9 +12,45 @@
             "description": "",
             "item": [
                 {
-                    "name": "http:\/\/localhost\/api\/withQueryParameters",
+                    "name": "api\/withQueryParameters",
                     "request": {
-                        "url": "http:\/\/localhost\/api\/withQueryParameters?location_id=consequatur&user_id=me&page=4&filters=consequatur&url_encoded=%2B+%5B%5D%26%3D",
+                        "url": {
+                            "protocol": "http",
+                            "host": "localhost",
+                            "path": "api\/withQueryParameters",
+                            "query": [
+                                {
+                                    "key": "location_id",
+                                    "value": "consequatur",
+                                    "description": "The id of the location.",
+                                    "disabled": false
+                                },
+                                {
+                                    "key": "user_id",
+                                    "value": "me",
+                                    "description": "The id of the user.",
+                                    "disabled": false
+                                },
+                                {
+                                    "key": "page",
+                                    "value": "4",
+                                    "description": "The page number.",
+                                    "disabled": false
+                                },
+                                {
+                                    "key": "filters",
+                                    "value": "consequatur",
+                                    "description": "The filters.",
+                                    "disabled": false
+                                },
+                                {
+                                    "key": "url_encoded",
+                                    "value": "%2B+%5B%5D%26%3D",
+                                    "description": "Used for testing that URL parameters will be URL-encoded where needed.",
+                                    "disabled": false
+                                }
+                            ]
+                        },
                         "method": "GET",
                         "header": [
                             {

--- a/tests/Fixtures/collection_with_secure_url.json
+++ b/tests/Fixtures/collection_with_secure_url.json
@@ -14,7 +14,12 @@
                 {
                     "name": "Example title.",
                     "request": {
-                        "url": "https:\/\/yourapp.app\/api\/test",
+                        "url": {
+                            "protocol": "https",
+                            "host": "yourapp.app",
+                            "path": "api/test",
+                            "query": []
+                        },
                         "method": "GET",
                         "header": [
                             {
@@ -35,9 +40,14 @@
                     }
                 },
                 {
-                    "name": "https:\/\/yourapp.app\/api\/responseTag",
+                    "name": "api\/responseTag",
                     "request": {
-                        "url": "https:\/\/yourapp.app\/api\/responseTag",
+                        "url": {
+                            "protocol": "https",
+                            "host": "yourapp.app",
+                            "path": "api/responseTag",
+                            "query": []
+                        },
                         "method": "POST",
                         "header": [
                             {

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -275,8 +275,8 @@ class GenerateDocumentationTest extends TestCase
         $this->artisan('apidoc:generate');
 
         $generatedCollection = json_decode(file_get_contents(__DIR__.'/../public/docs/collection.json'));
-        $endpointUrl = $generatedCollection->item[0]->item[0]->request->url;
-        $this->assertTrue(Str::startsWith($endpointUrl, $domain));
+        $endpointUrl = $generatedCollection->item[0]->item[0]->request->url->host;
+        $this->assertTrue(Str::startsWith($endpointUrl, 'somedomain.test'));
     }
 
     /** @test */

--- a/tests/Unit/PostmanCollectionWriterTest.php
+++ b/tests/Unit/PostmanCollectionWriterTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Mpociot\ApiDoc\Tests\Unit;
+
+use Illuminate\Support\Collection;
+use Mpociot\ApiDoc\Writing\PostmanCollectionWriter;
+use Orchestra\Testbench\TestCase;
+
+class PostmanCollectionWriterTest extends TestCase
+{
+    public function testNameIsPresentInCollection()
+    {
+        \Config::set('apidoc.postman', [
+            'name' => 'Test collection',
+        ]);
+
+        $writer = new PostmanCollectionWriter(new Collection(), '');
+        $collection = $writer->getCollection();
+
+        $this->assertSame('Test collection', json_decode($collection)->info->name);
+    }
+
+    public function testFallbackCollectionNameIsUsed()
+    {
+        \Config::set('app.name', 'Fake App');
+
+        $writer = new PostmanCollectionWriter(new Collection(), '');
+        $collection = $writer->getCollection();
+
+        $this->assertSame('Fake App API', json_decode($collection)->info->name);
+    }
+
+    public function testDescriptionIsPresentInCollection()
+    {
+        \Config::set('apidoc.postman', [
+            'description' => 'A fake description',
+        ]);
+
+        $writer = new PostmanCollectionWriter(new Collection(), '');
+        $collection = $writer->getCollection();
+
+        $this->assertSame('A fake description', json_decode($collection)->info->description);
+    }
+
+    public function testAuthIsNotIncludedWhenNull()
+    {
+        $writer = new PostmanCollectionWriter(new Collection(), '');
+        $collection = $writer->getCollection();
+
+        $this->assertArrayNotHasKey('auth', json_decode($collection, true));
+    }
+
+    public function testAuthIsIncludedVerbatim()
+    {
+        $auth = [
+            'type' => 'test',
+            'test' => ['a' => 1],
+        ];
+        \Config::set('apidoc.postman', [
+            'auth' => $auth,
+        ]);
+
+        $writer = new PostmanCollectionWriter(new Collection(), '');
+        $collection = $writer->getCollection();
+
+        $this->assertSame($auth, json_decode($collection, true)['auth']);
+    }
+
+    public function testEndpointIsParsed()
+    {
+        $route = $this->fakeRoute('some/path');
+
+        // Ensure method is set correctly for assertion later
+        $route['methods'] = ['GET'];
+
+        $collection = $this->fakeCollection([$route], 'Group');
+
+        $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        $this->assertSame('Group', data_get($collection, 'item.0.name'), 'Group name exists');
+
+        $item = data_get($collection, 'item.0.item.0');
+        $this->assertSame('some/path', $item['name'], 'Name defaults to path');
+        $this->assertSame('http', data_get($item, 'request.url.protocol'), 'Protocol defaults to http');
+        $this->assertSame('fake.localhost', data_get($item, 'request.url.host'), 'Host uses what\'s given');
+        $this->assertSame('some/path', data_get($item, 'request.url.path'), 'Path is set correctly');
+        $this->assertEmpty(data_get($item, 'request.url.query'), 'Query parameters are empty');
+        $this->assertSame('GET', data_get($item, 'request.method'), 'Method is correctly resolved');
+        $this->assertContains([
+            'key' => 'Accept',
+            'value' => 'application/json',
+        ], data_get($item, 'request.header'), 'JSON Accept header is added');
+    }
+
+    public function testHttpsProtocolIsDetected()
+    {
+        $collection = $this->fakeCollection([$this->fakeRoute('fake')]);
+        $writer = new PostmanCollectionWriter($collection, 'https://fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        $this->assertSame('https', data_get($collection, 'item.0.item.0.request.url.protocol'));
+    }
+
+    public function testHeadersArePulledFromRoute()
+    {
+        $route = $this->fakeRoute('some/path');
+
+        $route['headers'] = ['X-Fake' => 'Test'];
+
+        $collection = $this->fakeCollection([$route], 'Group');
+        $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        $this->assertContains([
+            'key' => 'X-Fake',
+            'value' => 'Test',
+        ], data_get($collection, 'item.0.item.0.request.header'));
+    }
+
+    public function testUrlParametersAreConverted()
+    {
+        $collection = $this->fakeCollection([$this->fakeRoute('fake/{param}')]);
+        $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        $item = data_get($collection, 'item.0.item.0');
+        $this->assertSame('fake/{param}', $item['name'], 'Name defaults to path');
+        $this->assertSame('fake/:param', data_get($item, 'request.url.path'), 'Path is converted');
+    }
+
+    public function testUrlParamsResolveTheirDocumentation()
+    {
+        $fakeRoute = $this->fakeRoute('fake/{param}');
+
+        $fakeRoute['urlParameters'] = ['param' => [
+            'description' => 'A test description for the test param',
+            'required' => true,
+            'value' => 'foobar',
+        ]];
+
+        $collection = $this->fakeCollection([$fakeRoute]);
+        $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        $variableData = data_get($collection, 'item.0.item.0.request.url.variable');
+
+        $this->assertCount(1, $variableData);
+        $this->assertSame([
+            'id' => 'param',
+            'key' => 'param',
+            'value' => 'foobar',
+            'description' => 'A test description for the test param',
+        ], $variableData[0]);
+    }
+
+    public function testQueryParametersAreDocumented()
+    {
+        $fakeRoute = $this->fakeRoute('fake/path');
+
+        $fakeRoute['queryParameters'] = ['limit' => [
+            'description' => 'A fake limit for my fake endpoint',
+            'required' => false,
+            'value' => 5,
+        ]];
+
+        $collection = $this->fakeCollection([$fakeRoute]);
+        $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        $variableData = data_get($collection, 'item.0.item.0.request.url.query');
+
+        $this->assertCount(1, $variableData);
+        $this->assertSame([
+            'key' => 'limit',
+            'value' => 5,
+            'description' => 'A fake limit for my fake endpoint',
+            'disabled' => false,
+        ], $variableData[0]);
+    }
+
+    public function testUrlParametersAreResolvedAsQueryParametersIfMissingFromPath()
+    {
+        $fakeRoute = $this->fakeRoute('fake/path');
+
+        $fakeRoute['urlParameters'] = ['limit' => [
+            'description' => 'A fake limit for my fake endpoint',
+            'required' => false,
+            'value' => 5,
+        ]];
+
+        $collection = $this->fakeCollection([$fakeRoute]);
+        $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        $variableData = data_get($collection, 'item.0.item.0.request.url.query');
+
+        $this->assertCount(1, $variableData);
+        $this->assertSame([
+            'key' => 'limit',
+            'value' => 5,
+            'description' => 'A fake limit for my fake endpoint',
+            'disabled' => false,
+        ], $variableData[0]);
+    }
+
+    public function testQueryParametersAreDisabledWithNoValueWhenNotRequired()
+    {
+        $fakeRoute = $this->fakeRoute('fake/path');
+        $fakeRoute['urlParameters'] = [
+            'required' => [
+                'description' => 'A required param with a null value',
+                'required' => true,
+                'value' => null,
+            ],
+            'not_required' => [
+                'description' => 'A not required param with a null value',
+                'required' => false,
+                'value' => null,
+            ]
+        ];
+
+        $collection = $this->fakeCollection([$fakeRoute]);
+        $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        $variableData = data_get($collection, 'item.0.item.0.request.url.query');
+
+        $this->assertCount(2, $variableData);
+        $this->assertContains([
+            'key' => 'required',
+            'value' => null,
+            'description' => 'A required param with a null value',
+            'disabled' => false,
+        ], $variableData);
+        $this->assertContains([
+            'key' => 'not_required',
+            'value' => null,
+            'description' => 'A not required param with a null value',
+            'disabled' => true,
+        ], $variableData);
+    }
+
+    /**
+     * @dataProvider provideAuthConfigHeaderData
+     */
+    public function testAuthAutoExcludesHeaderDefinitions(array $authConfig, array $expectedRemovedHeaders)
+    {
+        \Config::set('apidoc.postman', [
+            'auth' => $authConfig,
+        ]);
+
+        $route = $this->fakeRoute('some/path');
+        $route['headers'] = $expectedRemovedHeaders;
+        $collection = $this->fakeCollection([$route], 'Group');
+        $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        foreach ($expectedRemovedHeaders as $key => $value) {
+            $this->assertNotContains(compact('key', 'value'), data_get($collection, 'item.0.item.0.request.header'));
+        }
+    }
+
+    public function provideAuthConfigHeaderData()
+    {
+        yield [
+            ['type' => 'bearer', 'bearer' => ['token' => 'Test']],
+            ['Authorization' => 'Bearer Test']
+        ];
+
+        yield [
+            ['type' => 'apikey', 'apikey' => ['value' => 'Test', 'key' => 'X-Authorization']],
+            ['X-Authorization' => 'Test']
+        ];
+    }
+
+    public function testApiKeyAuthIsIgnoredIfExplicitlyNotInHeader()
+    {
+        \Config::set('apidoc.postman', [
+            'auth' => ['type' => 'apikey', 'apikey' => [
+                'value' => 'Test',
+                'key' => 'X-Authorization',
+                'in' => 'notheader'
+            ]],
+        ]);
+
+        $route = $this->fakeRoute('some/path');
+        $route['headers'] = ['X-Authorization' => 'Test'];
+        $collection = $this->fakeCollection([$route], 'Group');
+        $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
+        $collection = json_decode($writer->getCollection(), true);
+
+        $this->assertContains([
+            'key' => 'X-Authorization',
+            'value' => 'Test'
+        ], data_get($collection, 'item.0.item.0.request.header'));
+
+    }
+
+    protected function fakeRoute($path, $title = '')
+    {
+        return [
+            'uri' => $path,
+            'methods' => ['GET'],
+            'headers' => [],
+            'metadata' => [
+                'groupDescription' => '',
+                'title' => $title,
+            ],
+            'queryParameters' => [],
+            'urlParameters' => [],
+            'cleanBodyParameters' => [],
+        ];
+    }
+
+    protected function fakeCollection(array $routes, $groupName = 'Group')
+    {
+        return collect([$groupName => collect($routes)]);
+    }
+}

--- a/tests/Unit/PostmanCollectionWriterTest.php
+++ b/tests/Unit/PostmanCollectionWriterTest.php
@@ -68,12 +68,12 @@ class PostmanCollectionWriterTest extends TestCase
 
     public function testEndpointIsParsed()
     {
-        $route = $this->fakeRoute('some/path');
+        $route = $this->createMockRouteData('some/path');
 
         // Ensure method is set correctly for assertion later
         $route['methods'] = ['GET'];
 
-        $collection = $this->fakeCollection([$route], 'Group');
+        $collection = $this->createMockRouteGroup([$route], 'Group');
 
         $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
@@ -95,7 +95,7 @@ class PostmanCollectionWriterTest extends TestCase
 
     public function testHttpsProtocolIsDetected()
     {
-        $collection = $this->fakeCollection([$this->fakeRoute('fake')]);
+        $collection = $this->createMockRouteGroup([$this->createMockRouteData('fake')]);
         $writer = new PostmanCollectionWriter($collection, 'https://fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
 
@@ -104,11 +104,11 @@ class PostmanCollectionWriterTest extends TestCase
 
     public function testHeadersArePulledFromRoute()
     {
-        $route = $this->fakeRoute('some/path');
+        $route = $this->createMockRouteData('some/path');
 
         $route['headers'] = ['X-Fake' => 'Test'];
 
-        $collection = $this->fakeCollection([$route], 'Group');
+        $collection = $this->createMockRouteGroup([$route], 'Group');
         $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
 
@@ -120,7 +120,7 @@ class PostmanCollectionWriterTest extends TestCase
 
     public function testUrlParametersAreConverted()
     {
-        $collection = $this->fakeCollection([$this->fakeRoute('fake/{param}')]);
+        $collection = $this->createMockRouteGroup([$this->createMockRouteData('fake/{param}')]);
         $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
 
@@ -131,7 +131,7 @@ class PostmanCollectionWriterTest extends TestCase
 
     public function testUrlParamsResolveTheirDocumentation()
     {
-        $fakeRoute = $this->fakeRoute('fake/{param}');
+        $fakeRoute = $this->createMockRouteData('fake/{param}');
 
         $fakeRoute['urlParameters'] = ['param' => [
             'description' => 'A test description for the test param',
@@ -139,7 +139,7 @@ class PostmanCollectionWriterTest extends TestCase
             'value' => 'foobar',
         ]];
 
-        $collection = $this->fakeCollection([$fakeRoute]);
+        $collection = $this->createMockRouteGroup([$fakeRoute]);
         $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
 
@@ -156,7 +156,7 @@ class PostmanCollectionWriterTest extends TestCase
 
     public function testQueryParametersAreDocumented()
     {
-        $fakeRoute = $this->fakeRoute('fake/path');
+        $fakeRoute = $this->createMockRouteData('fake/path');
 
         $fakeRoute['queryParameters'] = ['limit' => [
             'description' => 'A fake limit for my fake endpoint',
@@ -164,7 +164,7 @@ class PostmanCollectionWriterTest extends TestCase
             'value' => 5,
         ]];
 
-        $collection = $this->fakeCollection([$fakeRoute]);
+        $collection = $this->createMockRouteGroup([$fakeRoute]);
         $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
 
@@ -181,7 +181,7 @@ class PostmanCollectionWriterTest extends TestCase
 
     public function testUrlParametersAreResolvedAsQueryParametersIfMissingFromPath()
     {
-        $fakeRoute = $this->fakeRoute('fake/path');
+        $fakeRoute = $this->createMockRouteData('fake/path');
 
         $fakeRoute['urlParameters'] = ['limit' => [
             'description' => 'A fake limit for my fake endpoint',
@@ -189,7 +189,7 @@ class PostmanCollectionWriterTest extends TestCase
             'value' => 5,
         ]];
 
-        $collection = $this->fakeCollection([$fakeRoute]);
+        $collection = $this->createMockRouteGroup([$fakeRoute]);
         $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
 
@@ -206,7 +206,7 @@ class PostmanCollectionWriterTest extends TestCase
 
     public function testQueryParametersAreDisabledWithNoValueWhenNotRequired()
     {
-        $fakeRoute = $this->fakeRoute('fake/path');
+        $fakeRoute = $this->createMockRouteData('fake/path');
         $fakeRoute['urlParameters'] = [
             'required' => [
                 'description' => 'A required param with a null value',
@@ -220,7 +220,7 @@ class PostmanCollectionWriterTest extends TestCase
             ],
         ];
 
-        $collection = $this->fakeCollection([$fakeRoute]);
+        $collection = $this->createMockRouteGroup([$fakeRoute]);
         $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
 
@@ -250,9 +250,9 @@ class PostmanCollectionWriterTest extends TestCase
             'auth' => $authConfig,
         ]);
 
-        $route = $this->fakeRoute('some/path');
+        $route = $this->createMockRouteData('some/path');
         $route['headers'] = $expectedRemovedHeaders;
-        $collection = $this->fakeCollection([$route], 'Group');
+        $collection = $this->createMockRouteGroup([$route], 'Group');
         $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
 
@@ -284,9 +284,9 @@ class PostmanCollectionWriterTest extends TestCase
             ]],
         ]);
 
-        $route = $this->fakeRoute('some/path');
+        $route = $this->createMockRouteData('some/path');
         $route['headers'] = ['X-Authorization' => 'Test'];
-        $collection = $this->fakeCollection([$route], 'Group');
+        $collection = $this->createMockRouteGroup([$route], 'Group');
         $writer = new PostmanCollectionWriter($collection, 'fake.localhost');
         $collection = json_decode($writer->getCollection(), true);
 
@@ -296,7 +296,7 @@ class PostmanCollectionWriterTest extends TestCase
         ], data_get($collection, 'item.0.item.0.request.header'));
     }
 
-    protected function fakeRoute($path, $title = '')
+    protected function createMockRouteData($path, $title = '')
     {
         return [
             'uri' => $path,
@@ -312,7 +312,7 @@ class PostmanCollectionWriterTest extends TestCase
         ];
     }
 
-    protected function fakeCollection(array $routes, $groupName = 'Group')
+    protected function createMockRouteGroup(array $routes, $groupName = 'Group')
     {
         return collect([$groupName => collect($routes)]);
     }

--- a/tests/Unit/PostmanCollectionWriterTest.php
+++ b/tests/Unit/PostmanCollectionWriterTest.php
@@ -173,7 +173,7 @@ class PostmanCollectionWriterTest extends TestCase
         $this->assertCount(1, $variableData);
         $this->assertSame([
             'key' => 'limit',
-            'value' => 5,
+            'value' => '5',
             'description' => 'A fake limit for my fake endpoint',
             'disabled' => false,
         ], $variableData[0]);
@@ -198,7 +198,7 @@ class PostmanCollectionWriterTest extends TestCase
         $this->assertCount(1, $variableData);
         $this->assertSame([
             'key' => 'limit',
-            'value' => 5,
+            'value' => '5',
             'description' => 'A fake limit for my fake endpoint',
             'disabled' => false,
         ], $variableData[0]);

--- a/tests/Unit/PostmanCollectionWriterTest.php
+++ b/tests/Unit/PostmanCollectionWriterTest.php
@@ -179,7 +179,7 @@ class PostmanCollectionWriterTest extends TestCase
         ], $variableData[0]);
     }
 
-    public function testUrlParametersAreResolvedAsQueryParametersIfMissingFromPath()
+    public function testUrlParametersAreNotIncludedIfMissingFromPath()
     {
         $fakeRoute = $this->createMockRouteData('fake/path');
 
@@ -195,19 +195,13 @@ class PostmanCollectionWriterTest extends TestCase
 
         $variableData = data_get($collection, 'item.0.item.0.request.url.query');
 
-        $this->assertCount(1, $variableData);
-        $this->assertSame([
-            'key' => 'limit',
-            'value' => '5',
-            'description' => 'A fake limit for my fake endpoint',
-            'disabled' => false,
-        ], $variableData[0]);
+        $this->assertCount(0, $variableData);
     }
 
     public function testQueryParametersAreDisabledWithNoValueWhenNotRequired()
     {
         $fakeRoute = $this->createMockRouteData('fake/path');
-        $fakeRoute['urlParameters'] = [
+        $fakeRoute['queryParameters'] = [
             'required' => [
                 'description' => 'A required param with a null value',
                 'required' => true,

--- a/tests/Unit/PostmanCollectionWriterTest.php
+++ b/tests/Unit/PostmanCollectionWriterTest.php
@@ -217,7 +217,7 @@ class PostmanCollectionWriterTest extends TestCase
                 'description' => 'A not required param with a null value',
                 'required' => false,
                 'value' => null,
-            ]
+            ],
         ];
 
         $collection = $this->fakeCollection([$fakeRoute]);
@@ -265,12 +265,12 @@ class PostmanCollectionWriterTest extends TestCase
     {
         yield [
             ['type' => 'bearer', 'bearer' => ['token' => 'Test']],
-            ['Authorization' => 'Bearer Test']
+            ['Authorization' => 'Bearer Test'],
         ];
 
         yield [
             ['type' => 'apikey', 'apikey' => ['value' => 'Test', 'key' => 'X-Authorization']],
-            ['X-Authorization' => 'Test']
+            ['X-Authorization' => 'Test'],
         ];
     }
 
@@ -280,7 +280,7 @@ class PostmanCollectionWriterTest extends TestCase
             'auth' => ['type' => 'apikey', 'apikey' => [
                 'value' => 'Test',
                 'key' => 'X-Authorization',
-                'in' => 'notheader'
+                'in' => 'notheader',
             ]],
         ]);
 
@@ -292,9 +292,8 @@ class PostmanCollectionWriterTest extends TestCase
 
         $this->assertContains([
             'key' => 'X-Authorization',
-            'value' => 'Test'
+            'value' => 'Test',
         ], data_get($collection, 'item.0.item.0.request.header'));
-
     }
 
     protected function fakeRoute($path, $title = '')


### PR DESCRIPTION
Along with resolving the `PostmanCollectionWriter` class with the application container, this PR extends support for Postman collections with the following features:

- Properly handle url parameters using the prefixed colon syntax (opposed to the Laravel-esque `{param}` syntax)
- Allow configuring the auth section of Postman collection config so your collection can indicate how to auth across all endpoints
- Resolve query params from url params if the URL param is not visible in the route path
- Add some documentation that was available but not exported in the Postman collection

The PostmanCollectionWriter has been significantly refactored and cleaned up, and a full suite of tests have been added for it.