### PR TITLE
Added support for the latest packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - php: 7.4
     - php: 7.4
       env: SETUP=lowest
-    - php: 7.4
+    - php: 7.3
       env: SETUP=lint
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,36 @@
+dist: bionic
 language: php
 
-php:
-  - 7.3
-  - 7.2
-
 env:
-  - PREFER_LOWEST=""
-  - PREFER_LOWEST="--prefer-lowest"
+  global:
+    - SETUP=stable
 
-jobs:
+matrix:
+  fast_finish: true
   include:
-    - script: composer lint
-      name: "Lint code"
-      php: 7.3
-      env: PREFER_LOWEST=""
+    - php: 7.2
+    - php: 7.2
+      env: SETUP=lowest
+    - php: 7.3
+    - php: 7.3
+      env: SETUP=lowest
+    - php: 7.4
+    - php: 7.4
+      env: SETUP=lowest
+    - php: 7.4
+      env: SETUP=lint
 
-script: composer test-ci
-before_script:
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
   - travis_retry composer self-update
-  - travis_retry composer update --no-interaction --prefer-dist $PREFER_LOWEST
+
+install:
+  - if [[ $SETUP = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi
+  - if [[ $SETUP = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable --no-suggest; fi
+  - if [[ $SETUP = 'lint' ]]; then travis_retry composer lint; fi
+
+script:
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
       env: SETUP=lowest
     - php: 7.4
       env: SETUP=lint
+      name: "Lint code"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 install:
   - if [[ $SETUP = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi
   - if [[ $SETUP = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable --no-suggest; fi
-  - if [[ $SETUP = 'lint' ]]; then travis_retry composer lint; fi
+  - if [[ $SETUP = 'lint' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; travis_retry composer lint; fi
 
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - php: 7.4
     - php: 7.4
       env: SETUP=lowest
-    - php: 7.3
+    - php: 7.4
       env: SETUP=lint
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -17,23 +17,24 @@
     "require": {
         "php": ">=7.2.0",
         "fzaninotto/faker": "^1.8",
-        "illuminate/routing": "^5.7|^6.0",
-        "illuminate/support": "^5.7|^6.0",
-        "illuminate/console": "^5.7|^6.0",
+        "illuminate/console": "^5.7|^6.0|^7.0",
+        "illuminate/routing": "^5.7|^6.0|^7.0",
+        "illuminate/support": "^5.7|^6.0|^7.0",
+        "league/flysystem": "^1.0",
         "mpociot/documentarian": "^0.3.0",
         "mpociot/reflection-docblock": "^1.0.1",
+        "nunomaduro/collision": "^3.0",
         "ramsey/uuid": "^3.8",
-        "symfony/var-exporter": "^4.0",
-        "league/flysystem": "^1.0",
-        "nunomaduro/collision": "^3.0"
+        "symfony/var-exporter": "^4.0|^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.7.0 || ^4.0",
-        "phpunit/phpunit": "^7.5.0",
         "dingo/api": "^2.3.0",
-        "mockery/mockery": "^1.2.0",
+        "dms/phpunit-arraysubset-asserts": "^0.1.0",
         "league/fractal": "^0.17.0",
-        "phpstan/phpstan": "^0.11.15"
+        "mockery/mockery": "^1.2.0",
+        "orchestra/testbench": "^3.7|^4.0",
+        "phpstan/phpstan": "^0.11.15",
+        "phpunit/phpunit": "^8.0"
     },
     "suggest": {
         "league/fractal": "Required for transformers support"

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": ">=7.2.0",
+        "ext-json": "*",
         "fzaninotto/faker": "^1.8",
         "illuminate/console": "^5.7|^6.0|^7.0",
         "illuminate/routing": "^5.7|^6.0|^7.0",
@@ -63,5 +64,9 @@
         "branch-alias": {
             "dev-v4": "4.x-dev"
         }
+    },
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
     level: 5
     reportUnmatchedIgnoredErrors: false
-    inferPrivatePropertyTypeFromConstructor:: true
+    inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         - '#Call to an undefined static method Illuminate\\Support\\Facades\\Route::getRoutes().#'
         - '#Call to an undefined static method Illuminate\\Support\\Facades\\URL::forceRootUrl()#'

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -89,6 +89,8 @@ class GenerateDocumentation extends Command
      * @param \Mpociot\ApiDoc\Extracting\Generator $generator
      * @param array $routes
      *
+     * @throws \ReflectionException
+     *
      * @return array
      */
     private function processRoutes(Generator $generator, array $routes)

--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -47,6 +47,8 @@ class Generator
      * @param \Illuminate\Routing\Route $route
      * @param array $routeRules Rules to apply when generating documentation for this route
      *
+     * @throws \ReflectionException
+     *
      * @return array
      */
     public function processRoute(Route $route, array $routeRules = [])

--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -51,7 +51,7 @@ class Generator
      */
     public function processRoute(Route $route, array $routeRules = [])
     {
-        list($controllerName, $methodName) = Utils::getRouteClassAndMethodNames($route->getAction());
+        [$controllerName, $methodName] = Utils::getRouteClassAndMethodNames($route->getAction());
         $controller = new ReflectionClass($controllerName);
         $method = $controller->getMethod($methodName);
 

--- a/src/Extracting/ParamHelpers.php
+++ b/src/Extracting/ParamHelpers.php
@@ -3,6 +3,7 @@
 namespace Mpociot\ApiDoc\Extracting;
 
 use Faker\Factory;
+use stdClass;
 
 trait ParamHelpers
 {
@@ -32,7 +33,7 @@ trait ParamHelpers
                 return [];
             },
             'object' => function () {
-                return new \stdClass;
+                return new stdClass;
             },
         ];
 

--- a/src/Extracting/RouteDocBlocker.php
+++ b/src/Extracting/RouteDocBlocker.php
@@ -20,6 +20,7 @@ class RouteDocBlocker
      * @param Route $route
      *
      * @throws \ReflectionException
+     * @throws \Exception
      *
      * @return array<string, DocBlock> Method and class docblocks
      */

--- a/src/Extracting/Strategies/Responses/UseTransformerTags.php
+++ b/src/Extracting/Strategies/Responses/UseTransformerTags.php
@@ -125,9 +125,9 @@ class UseTransformerTags extends Strategy
             $type = $modelTag->getContent();
         } else {
             $parameter = Arr::first($transformerMethod->getParameters());
-            if ($parameter->hasType() && ! $parameter->getType()->isBuiltin() && class_exists((string) $parameter->getType())) {
+            if ($parameter->hasType() && ! $parameter->getType()->isBuiltin() && class_exists($parameter->getType()->getName())) {
                 // Ladies and gentlemen, we have a type!
-                $type = (string) $parameter->getType();
+                $type = $parameter->getType()->getName();
             }
         }
 

--- a/src/Extracting/Strategies/Responses/UseTransformerTags.php
+++ b/src/Extracting/Strategies/Responses/UseTransformerTags.php
@@ -4,6 +4,7 @@ namespace Mpociot\ApiDoc\Extracting\Strategies\Responses;
 
 use Exception;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as IlluminateModel;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use League\Fractal\Manager;
@@ -34,7 +35,7 @@ class UseTransformerTags extends Strategy
      *
      * @return array|null
      */
-    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionMethod $method, array $rulesToApply, array $context = [])
+    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $rulesToApply, array $context = [])
     {
         $docBlocks = RouteDocBlocker::getDocBlocksFromRoute($route);
         /** @var DocBlock $methodDocBlock */
@@ -47,6 +48,7 @@ class UseTransformerTags extends Strategy
      * Get a response from the transformer tags.
      *
      * @param array $tags
+     * @param Route $route
      *
      * @return array|null
      */
@@ -57,7 +59,7 @@ class UseTransformerTags extends Strategy
                 return null;
             }
 
-            list($statusCode, $transformer) = $this->getStatusCodeAndTransformerClass($transformerTag);
+            [$statusCode, $transformer] = $this->getStatusCodeAndTransformerClass($transformerTag);
             $model = $this->getClassToBeTransformed($tags, (new ReflectionClass($transformer))->getMethod('transform'));
             $modelInstance = $this->instantiateTransformerModel($model);
 
@@ -81,7 +83,7 @@ class UseTransformerTags extends Strategy
                     'content' => $response->getContent(),
                 ],
             ];
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             echo 'Exception thrown when fetching transformer response for ['.implode(',', $route->methods)."] {$route->uri}.\n";
             if (Flags::$shouldBeVerbose) {
                 Utils::dumpException($e);
@@ -111,6 +113,8 @@ class UseTransformerTags extends Strategy
     /**
      * @param array $tags
      * @param ReflectionMethod $transformerMethod
+     *
+     * @throws Exception
      *
      * @return string
      */
@@ -153,20 +157,20 @@ class UseTransformerTags extends Strategy
             $type = ltrim($type, '\\');
 
             return factory($type)->make();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             if (Flags::$shouldBeVerbose) {
                 echo "Eloquent model factory failed to instantiate {$type}; trying to fetch from database.\n";
             }
 
             $instance = new $type;
-            if ($instance instanceof \Illuminate\Database\Eloquent\Model) {
+            if ($instance instanceof IlluminateModel) {
                 try {
                     // we can't use a factory but can try to get one from the database
                     $firstInstance = $type::first();
                     if ($firstInstance) {
                         return $firstInstance;
                     }
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     // okay, we'll stick with `new`
                     if (Flags::$shouldBeVerbose) {
                         echo "Failed to fetch first {$type} from database; using `new` to instantiate.\n";

--- a/src/Tools/Utils.php
+++ b/src/Tools/Utils.php
@@ -94,6 +94,14 @@ class Utils
         $fs->deleteDir($dir);
     }
 
+    /**
+     * @param mixed $value
+     * @param int $indentationLevel
+     *
+     * @throws \Symfony\Component\VarExporter\Exception\ExceptionInterface
+     *
+     * @return string
+     */
     public static function printPhpValue($value, $indentationLevel = 0)
     {
         $output = VarExporter::export($value);

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -65,8 +65,8 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $output = $this->artisan('apidoc:generate');
 
-        $this->assertContains('Skipping route: [GET] api/closure', $output);
-        $this->assertContains('Processed route: [GET] api/test', $output);
+        $this->assertStringContainsString('Skipping route: [GET] api/closure', $output);
+        $this->assertStringContainsString('Processed route: [GET] api/test', $output);
     }
 
     /** @test */
@@ -85,8 +85,8 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.versions' => ['v1']]);
         $output = $this->artisan('apidoc:generate');
 
-        $this->assertContains('Skipping route: [GET] closure', $output);
-        $this->assertContains('Processed route: [GET] test', $output);
+        $this->assertStringContainsString('Skipping route: [GET] closure', $output);
+        $this->assertStringContainsString('Processed route: [GET] test', $output);
     }
 
     /** @test */
@@ -97,8 +97,8 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $output = $this->artisan('apidoc:generate');
 
-        $this->assertNotContains('Skipping route: [GET] api/array/test', $output);
-        $this->assertContains('Processed route: [GET] api/array/test', $output);
+        $this->assertStringNotContainsString('Skipping route: [GET] api/array/test', $output);
+        $this->assertStringContainsString('Processed route: [GET] api/array/test', $output);
     }
 
     /** @test */
@@ -110,8 +110,8 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $output = $this->artisan('apidoc:generate');
 
-        $this->assertContains('Skipping route: [GET] api/skip', $output);
-        $this->assertContains('Processed route: [GET] api/test', $output);
+        $this->assertStringContainsString('Skipping route: [GET] api/skip', $output);
+        $this->assertStringContainsString('Processed route: [GET] api/test', $output);
     }
 
     /** @test */
@@ -122,8 +122,8 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $output = $this->artisan('apidoc:generate');
 
-        $this->assertContains('Skipping route: [GET] api/non-existent', $output);
-        $this->assertContains('@responseFile i-do-not-exist.json does not exist', $output);
+        $this->assertStringContainsString('Skipping route: [GET] api/non-existent', $output);
+        $this->assertStringContainsString('@responseFile i-do-not-exist.json does not exist', $output);
     }
 
     /** @test */
@@ -392,7 +392,7 @@ class GenerateDocumentationTest extends TestCase
         $this->artisan('apidoc:generate');
 
         $generatedMarkdown = file_get_contents(__DIR__.'/../resources/docs/source/index.md');
-        $this->assertContains('Лорем ипсум долор сит амет', $generatedMarkdown);
+        $this->assertStringContainsString('Лорем ипсум долор сит амет', $generatedMarkdown);
     }
 
     /** @test */
@@ -437,7 +437,7 @@ class GenerateDocumentationTest extends TestCase
 
         $this->assertNull($thrownException);
         $generatedMarkdown = file_get_contents(__DIR__.'/../resources/docs/source/index.md');
-        $this->assertContains('Group A', $generatedMarkdown);
-        $this->assertContains('Group B', $generatedMarkdown);
+        $this->assertStringContainsString('Group A', $generatedMarkdown);
+        $this->assertStringContainsString('Group B', $generatedMarkdown);
     }
 }

--- a/tests/TestHelpers.php
+++ b/tests/TestHelpers.php
@@ -48,6 +48,6 @@ trait TestHelpers
     {
         $haystack = preg_replace('/\s/', '', $haystack);
         $needle = preg_replace('/\s/', '', $needle);
-        $this->assertContains($needle, $haystack);
+        $this->assertStringContainsString($needle, $haystack);
     }
 }

--- a/tests/Unit/GeneratorPluginSystemTestCase.php
+++ b/tests/Unit/GeneratorPluginSystemTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Mpociot\ApiDoc\Tests\Unit;
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Illuminate\Routing\Route;
 use Mpociot\ApiDoc\ApiDocGeneratorServiceProvider;
 use Mpociot\ApiDoc\Extracting\Generator;
@@ -13,6 +14,8 @@ use ReflectionMethod;
 
 class GeneratorPluginSystemTestCase extends LaravelGeneratorTest
 {
+    use ArraySubsetAsserts;
+
     /**
      * @var \Mpociot\ApiDoc\Extracting\Generator
      */

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -4,6 +4,7 @@
 
 namespace Mpociot\ApiDoc\Tests\Unit;
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Illuminate\Support\Arr;
 use Mpociot\ApiDoc\ApiDocGeneratorServiceProvider;
 use Mpociot\ApiDoc\Extracting\Generator;
@@ -14,6 +15,8 @@ use Orchestra\Testbench\TestCase;
 
 abstract class GeneratorTestCase extends TestCase
 {
+    use ArraySubsetAsserts;
+
     /**
      * @var \Mpociot\ApiDoc\Extracting\Generator
      */

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -472,21 +472,21 @@ abstract class GeneratorTestCase extends TestCase
         $content = json_decode($response['content'], true);
         $this->assertIsArray($content);
         $this->assertArraySubset([
-                'data' => [
-                    [
-                        'id' => 4,
-                        'name' => 'Tested Again',
-                        'email' => 'a@b.com',
-                    ],
-                    [
-                        'id' => 4,
-                        'name' => 'Tested Again',
-                        'email' => 'a@b.com',
-                    ],
+            'data' => [
+                [
+                    'id' => 4,
+                    'name' => 'Tested Again',
+                    'email' => 'a@b.com',
                 ],
-                'links' => [
-                    'self' => 'link-value',
+                [
+                    'id' => 4,
+                    'name' => 'Tested Again',
+                    'email' => 'a@b.com',
                 ],
+            ],
+            'links' => [
+                'self' => 'link-value',
+            ],
         ], $content);
     }
 

--- a/tests/Unit/RouteMatcherTest.php
+++ b/tests/Unit/RouteMatcherTest.php
@@ -37,7 +37,7 @@ class RouteMatcherTest extends TestCase
         $routes = $matcher->getRoutes();
         $this->assertCount(6, $routes);
         foreach ($routes as $route) {
-            $this->assertContains('domain1', $route['route']->getDomain());
+            $this->assertStringContainsString('domain1', $route['route']->getDomain());
         }
 
         $routeRules[0]['match']['domains'] = ['domain2.*'];
@@ -45,7 +45,7 @@ class RouteMatcherTest extends TestCase
         $routes = $matcher->getRoutes();
         $this->assertCount(6, $routes);
         foreach ($routes as $route) {
-            $this->assertContains('domain2', $route['route']->getDomain());
+            $this->assertStringContainsString('domain2', $route['route']->getDomain());
         }
     }
 
@@ -70,7 +70,7 @@ class RouteMatcherTest extends TestCase
         $routes = $matcher->getRoutes();
         $this->assertCount(6, $routes);
         foreach ($routes as $route) {
-            $this->assertContains('domain1', $route['route']->getDomain());
+            $this->assertStringContainsString('domain1', $route['route']->getDomain());
         }
 
         $routeRules[0]['match']['domains'] = ['domain2.*'];
@@ -78,7 +78,7 @@ class RouteMatcherTest extends TestCase
         $routes = $matcher->getRoutes();
         $this->assertCount(6, $routes);
         foreach ($routes as $route) {
-            $this->assertContains('domain2', $route['route']->getDomain());
+            $this->assertStringContainsString('domain2', $route['route']->getDomain());
         }
     }
 


### PR DESCRIPTION
Changed:

- Updated .travis.yml
- Fixed error applying the parameter in the `phpstan.neon`
- Added support for the latest packages. [Also see](https://github.com/sebastianbergmann/phpunit/pull/3765/commits/015ac15d7f3b1d4da8d40d18ccbf81339314bba0).
- Added php-json extension into composer.json
- Updated dockblocks and optimized qualified classes
- Packages in `composer.json` file sorted alphabetically
- Added call of travis-ci tests for PHP 7.4

PS: Laravel 7 is planned to be released in February, so I immediately included it in the composer.json file.