### PR TITLE
Feature/custom info view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mpociot/laravel-apidoc-generator",
+    "name": "nevercom/laravel-apidoc-generator",
     "license": "MIT",
     "description": "Generate beautiful API documentation from your Laravel application",
     "keywords": [
@@ -7,11 +7,15 @@
         "Documentation",
         "Laravel"
     ],
-    "homepage": "http://github.com/mpociot/laravel-apidoc-generator",
+    "homepage": "http://github.com/nevercom/laravel-apidoc-generator",
     "authors": [
         {
             "name": "Marcel Pociot",
             "email": "m.pociot@gmail.com"
+        },
+        {
+            "name": "Mohammad Azam Rahmanpour",
+            "email": "nevercom@gmail.com"
         }
     ],
     "require": {

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -229,6 +229,15 @@ return [
     'logo' => false,
 
     /*
+     * Custom View Identifier for `info` section.
+     * if is set, this view will be rendered in the generation process instead
+     * of the default view (apidoc::partial.info)
+     *
+     * it should be a valid laravel view identifier.
+     * For example: 'doc.info' (source path: resources/views/doc/info.blade.php)
+     */
+    'info_view' => '',
+    /*
      * Name for the group of routes which do not have a @group set.
      */
     'default_group' => 'general',

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -94,7 +94,7 @@ class Writer
         $targetFile = $this->sourceOutputPath.'/source/index.md';
         $compareFile = $this->sourceOutputPath.'/source/.compare.md';
 
-        $infoText = view('apidoc::partials.info')
+        $infoText = view($this->config->get('info_view', 'apidoc::partials.info'))
             ->with('outputPath', 'docs')
             ->with('showPostmanCollectionButton', $this->shouldGeneratePostmanCollection);
 


### PR DESCRIPTION
This will allow user to use custom view for **Info** section of the documentation.

It will be useful in case the documentation needs to explain various aspects of API, and not just the route definitions.

Also it would be nice to add some styling to visually distinguish the **Info** section and the **Route Definition** section, but AFAIK this has to be applied to `documentarian` library.