### PR TITLE
allow user to use custom view for `Info` section of the documentation

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -229,6 +229,15 @@ return [
     'logo' => false,
 
     /*
+     * Custom View Identifier for `info` section.
+     * if is set, this view will be rendered in the generation process instead
+     * of the default view (apidoc::partial.info)
+     *
+     * it should be a valid laravel view identifier.
+     * For example: 'doc.info' (source path: resources/views/doc/info.blade.php)
+     */
+    'info_view' => '',
+    /*
      * Name for the group of routes which do not have a @group set.
      */
     'default_group' => 'general',

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -94,7 +94,7 @@ class Writer
         $targetFile = $this->sourceOutputPath.'/source/index.md';
         $compareFile = $this->sourceOutputPath.'/source/.compare.md';
 
-        $infoText = view($this->config->get('info_view', 'apidoc::partials.info'))
+        $infoText = view($this->config->get('info_view') ?: 'apidoc::partials.info')
             ->with('outputPath', 'docs')
             ->with('showPostmanCollectionButton', $this->shouldGeneratePostmanCollection);
 

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -94,7 +94,7 @@ class Writer
         $targetFile = $this->sourceOutputPath.'/source/index.md';
         $compareFile = $this->sourceOutputPath.'/source/.compare.md';
 
-        $infoText = view('apidoc::partials.info')
+        $infoText = view($this->config->get('info_view', 'apidoc::partials.info'))
             ->with('outputPath', 'docs')
             ->with('showPostmanCollectionButton', $this->shouldGeneratePostmanCollection);
 


### PR DESCRIPTION
This will allow user to use custom view for Info section of the documentation.

It will be useful in case the documentation needs to explain various aspects of API, and not just the route definitions.

Also it would be nice to add some styling to visually distinguish the Info section and the Route Definition section, but AFAIK this has to be applied to documentarian library.