### PR TITLE
Shim URL::formatRoot() on Lumen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "require-dev": {
         "dingo/api": "^2.3.0",
         "dms/phpunit-arraysubset-asserts": "^0.1.0",
+        "laravel/lumen-framework": "^5.7|^6.0|^7.0",
         "league/fractal": "^0.17.0",
         "mockery/mockery": "^1.2.0",
         "orchestra/testbench": "^3.7|^4.0",

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Ramsey\Uuid\Uuid;
+use ReflectionMethod;
 
 class PostmanCollectionWriter
 {
@@ -38,7 +39,7 @@ class PostmanCollectionWriter
     {
         $this->routeGroups = $routeGroups;
         $this->protocol = Str::startsWith($baseUrl, 'https') ? 'https' : 'http';
-        $this->baseUrl = URL::formatRoot('', $baseUrl);
+        $this->baseUrl = $this->getBaseUrl($baseUrl);
         $this->auth = config('apidoc.postman.auth');
     }
 
@@ -179,6 +180,18 @@ class PostmanCollectionWriter
                 return $spec['key'];
             default:
                 return null;
+        }
+    }
+
+    protected function getBaseUrl($baseUrl)
+    {
+        if (Str::contains(app()->version(), 'Lumen')) { //Is Lumen
+            $reflectionMethod = new ReflectionMethod(\Laravel\Lumen\Routing\UrlGenerator::class, 'getRootUrl');
+            $reflectionMethod->setAccessible(true);
+            $url = app('url');
+            return $reflectionMethod->invokeArgs($url, ['', $baseUrl]);
+        } else { //Is Laravel
+            return URL::formatRoot('', $baseUrl);
         }
     }
 }

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -189,9 +189,10 @@ class PostmanCollectionWriter
             $reflectionMethod = new ReflectionMethod(\Laravel\Lumen\Routing\UrlGenerator::class, 'getRootUrl');
             $reflectionMethod->setAccessible(true);
             $url = app('url');
+
             return $reflectionMethod->invokeArgs($url, ['', $baseUrl]);
-        } else { //Is Laravel
-            return URL::formatRoot('', $baseUrl);
         }
+
+        return URL::formatRoot('', $baseUrl);
     }
 }


### PR DESCRIPTION
In the URL class, lumen does not have the method formatRoot