### PR TITLE
Implement support for closures

### DIFF
--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 use Mpociot\ApiDoc\Tools\DocumentationConfig;
 use Mpociot\ApiDoc\Tools\Utils;
 use ReflectionClass;
-use ReflectionMethod;
+use ReflectionFunctionAbstract;
 
 class Generator
 {
@@ -55,7 +55,7 @@ class Generator
     {
         [$controllerName, $methodName] = Utils::getRouteClassAndMethodNames($route->getAction());
         $controller = new ReflectionClass($controllerName);
-        $method = $controller->getMethod($methodName);
+        $method = Utils::reflectRouteMethod([$controllerName, $methodName]);
 
         $parsedRoute = [
             'id' => md5($this->getUri($route).':'.implode($this->getMethods($route))),
@@ -88,7 +88,7 @@ class Generator
         return $parsedRoute;
     }
 
-    protected function fetchMetadata(ReflectionClass $controller, ReflectionMethod $method, Route $route, array $rulesToApply, array $context = [])
+    protected function fetchMetadata(ReflectionClass $controller, ReflectionFunctionAbstract $method, Route $route, array $rulesToApply, array $context = [])
     {
         $context['metadata'] = [
             'groupName' => $this->config->get('default_group', ''),
@@ -101,22 +101,22 @@ class Generator
         return $this->iterateThroughStrategies('metadata', $context, [$route, $controller, $method, $rulesToApply]);
     }
 
-    protected function fetchUrlParameters(ReflectionClass $controller, ReflectionMethod $method, Route $route, array $rulesToApply, array $context = [])
+    protected function fetchUrlParameters(ReflectionClass $controller, ReflectionFunctionAbstract $method, Route $route, array $rulesToApply, array $context = [])
     {
         return $this->iterateThroughStrategies('urlParameters', $context, [$route, $controller, $method, $rulesToApply]);
     }
 
-    protected function fetchQueryParameters(ReflectionClass $controller, ReflectionMethod $method, Route $route, array $rulesToApply, array $context = [])
+    protected function fetchQueryParameters(ReflectionClass $controller, ReflectionFunctionAbstract $method, Route $route, array $rulesToApply, array $context = [])
     {
         return $this->iterateThroughStrategies('queryParameters', $context, [$route, $controller, $method, $rulesToApply]);
     }
 
-    protected function fetchBodyParameters(ReflectionClass $controller, ReflectionMethod $method, Route $route, array $rulesToApply, array $context = [])
+    protected function fetchBodyParameters(ReflectionClass $controller, ReflectionFunctionAbstract $method, Route $route, array $rulesToApply, array $context = [])
     {
         return $this->iterateThroughStrategies('bodyParameters', $context, [$route, $controller, $method, $rulesToApply]);
     }
 
-    protected function fetchResponses(ReflectionClass $controller, ReflectionMethod $method, Route $route, array $rulesToApply, array $context = [])
+    protected function fetchResponses(ReflectionClass $controller, ReflectionFunctionAbstract $method, Route $route, array $rulesToApply, array $context = [])
     {
         $responses = $this->iterateThroughStrategies('responses', $context, [$route, $controller, $method, $rulesToApply]);
         if (count($responses)) {
@@ -128,7 +128,7 @@ class Generator
         return [];
     }
 
-    protected function fetchRequestHeaders(ReflectionClass $controller, ReflectionMethod $method, Route $route, array $rulesToApply, array $context = [])
+    protected function fetchRequestHeaders(ReflectionClass $controller, ReflectionFunctionAbstract $method, Route $route, array $rulesToApply, array $context = [])
     {
         $headers = $this->iterateThroughStrategies('headers', $context, [$route, $controller, $method, $rulesToApply]);
 

--- a/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
@@ -11,13 +11,13 @@ use Mpociot\ApiDoc\Extracting\Strategies\Strategy;
 use Mpociot\Reflection\DocBlock;
 use Mpociot\Reflection\DocBlock\Tag;
 use ReflectionClass;
-use ReflectionMethod;
+use ReflectionFunctionAbstract;
 
 class GetFromBodyParamTag extends Strategy
 {
     use ParamHelpers;
 
-    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
+    public function __invoke(Route $route, ReflectionClass $controller, ReflectionFunctionAbstract $method, array $routeRules, array $context = [])
     {
         foreach ($method->getParameters() as $param) {
             $paramType = $param->getType();

--- a/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
+++ b/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
@@ -8,11 +8,11 @@ use Mpociot\ApiDoc\Extracting\Strategies\Strategy;
 use Mpociot\Reflection\DocBlock;
 use Mpociot\Reflection\DocBlock\Tag;
 use ReflectionClass;
-use ReflectionMethod;
+use ReflectionFunctionAbstract;
 
 class GetFromDocBlocks extends Strategy
 {
-    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
+    public function __invoke(Route $route, ReflectionClass $controller, ReflectionFunctionAbstract $method, array $routeRules, array $context = [])
     {
         $docBlocks = RouteDocBlocker::getDocBlocksFromRoute($route);
         /** @var DocBlock $methodDocBlock */

--- a/src/Extracting/Strategies/QueryParameters/GetFromQueryParamTag.php
+++ b/src/Extracting/Strategies/QueryParameters/GetFromQueryParamTag.php
@@ -12,13 +12,13 @@ use Mpociot\ApiDoc\Extracting\Strategies\Strategy;
 use Mpociot\Reflection\DocBlock;
 use Mpociot\Reflection\DocBlock\Tag;
 use ReflectionClass;
-use ReflectionMethod;
+use ReflectionFunctionAbstract;
 
 class GetFromQueryParamTag extends Strategy
 {
     use ParamHelpers;
 
-    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
+    public function __invoke(Route $route, ReflectionClass $controller, ReflectionFunctionAbstract $method, array $routeRules, array $context = [])
     {
         foreach ($method->getParameters() as $param) {
             $paramType = $param->getType();

--- a/src/Extracting/Strategies/RequestHeaders/GetFromRouteRules.php
+++ b/src/Extracting/Strategies/RequestHeaders/GetFromRouteRules.php
@@ -5,11 +5,11 @@ namespace Mpociot\ApiDoc\Extracting\Strategies\RequestHeaders;
 use Illuminate\Routing\Route;
 use Mpociot\ApiDoc\Extracting\Strategies\Strategy;
 use ReflectionClass;
-use ReflectionMethod;
+use ReflectionFunctionAbstract;
 
 class GetFromRouteRules extends Strategy
 {
-    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
+    public function __invoke(Route $route, ReflectionClass $controller, ReflectionFunctionAbstract $method, array $routeRules, array $context = [])
     {
         return $routeRules['headers'] ?? [];
     }

--- a/src/Extracting/Strategies/Responses/ResponseCalls.php
+++ b/src/Extracting/Strategies/Responses/ResponseCalls.php
@@ -22,13 +22,13 @@ class ResponseCalls extends Strategy
     /**
      * @param Route $route
      * @param \ReflectionClass $controller
-     * @param \ReflectionMethod $method
+     * @param \ReflectionFunctionAbstract $method
      * @param array $routeRules
      * @param array $context
      *
      * @return array|null
      */
-    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionMethod $method, array $routeRules, array $context = [])
+    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionFunctionAbstract $method, array $routeRules, array $context = [])
     {
         $rulesToApply = $routeRules['response_calls'] ?? [];
         if (! $this->shouldMakeApiCall($route, $rulesToApply, $context)) {

--- a/src/Extracting/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Extracting/Strategies/Responses/UseApiResourceTags.php
@@ -18,7 +18,7 @@ use Mpociot\ApiDoc\Tools\Utils;
 use Mpociot\Reflection\DocBlock;
 use Mpociot\Reflection\DocBlock\Tag;
 use ReflectionClass;
-use ReflectionMethod;
+use ReflectionFunctionAbstract;
 
 /**
  * Parse an Eloquent API resource response from the docblock ( @apiResource || @apiResourcecollection ).
@@ -28,7 +28,7 @@ class UseApiResourceTags extends Strategy
     /**
      * @param Route $route
      * @param ReflectionClass $controller
-     * @param ReflectionMethod $method
+     * @param ReflectionFunctionAbstract $method
      * @param array $rulesToApply
      * @param array $context
      *
@@ -36,7 +36,7 @@ class UseApiResourceTags extends Strategy
      *
      * @return array|null
      */
-    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionMethod $method, array $rulesToApply, array $context = [])
+    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionFunctionAbstract $method, array $rulesToApply, array $context = [])
     {
         $docBlocks = RouteDocBlocker::getDocBlocksFromRoute($route);
         /** @var DocBlock $methodDocBlock */

--- a/src/Extracting/Strategies/Responses/UseResponseFileTag.php
+++ b/src/Extracting/Strategies/Responses/UseResponseFileTag.php
@@ -16,7 +16,7 @@ class UseResponseFileTag extends Strategy
     /**
      * @param Route $route
      * @param \ReflectionClass $controller
-     * @param \ReflectionMethod $method
+     * @param \ReflectionFunctionAbstract $method
      * @param array $routeRules
      * @param array $context
      *
@@ -24,7 +24,7 @@ class UseResponseFileTag extends Strategy
      *
      * @return array|null
      */
-    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionMethod $method, array $routeRules, array $context = [])
+    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionFunctionAbstract $method, array $routeRules, array $context = [])
     {
         $docBlocks = RouteDocBlocker::getDocBlocksFromRoute($route);
         /** @var DocBlock $methodDocBlock */

--- a/src/Extracting/Strategies/Responses/UseResponseTag.php
+++ b/src/Extracting/Strategies/Responses/UseResponseTag.php
@@ -16,7 +16,7 @@ class UseResponseTag extends Strategy
     /**
      * @param Route $route
      * @param \ReflectionClass $controller
-     * @param \ReflectionMethod $method
+     * @param \ReflectionFunctionAbstract $method
      * @param array $routeRules
      * @param array $context
      *
@@ -24,7 +24,7 @@ class UseResponseTag extends Strategy
      *
      * @return array|null
      */
-    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionMethod $method, array $routeRules, array $context = [])
+    public function __invoke(Route $route, \ReflectionClass $controller, \ReflectionFunctionAbstract $method, array $routeRules, array $context = [])
     {
         $docBlocks = RouteDocBlocker::getDocBlocksFromRoute($route);
         /** @var DocBlock $methodDocBlock */

--- a/src/Extracting/Strategies/Responses/UseTransformerTags.php
+++ b/src/Extracting/Strategies/Responses/UseTransformerTags.php
@@ -17,7 +17,7 @@ use Mpociot\ApiDoc\Tools\Utils;
 use Mpociot\Reflection\DocBlock;
 use Mpociot\Reflection\DocBlock\Tag;
 use ReflectionClass;
-use ReflectionMethod;
+use ReflectionFunctionAbstract;
 
 /**
  * Parse a transformer response from the docblock ( @transformer || @transformercollection ).
@@ -27,7 +27,7 @@ class UseTransformerTags extends Strategy
     /**
      * @param Route $route
      * @param ReflectionClass $controller
-     * @param ReflectionMethod $method
+     * @param ReflectionFunctionAbstract $method
      * @param array $rulesToApply
      * @param array $context
      *
@@ -35,7 +35,7 @@ class UseTransformerTags extends Strategy
      *
      * @return array|null
      */
-    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $rulesToApply, array $context = [])
+    public function __invoke(Route $route, ReflectionClass $controller, ReflectionFunctionAbstract $method, array $rulesToApply, array $context = [])
     {
         $docBlocks = RouteDocBlocker::getDocBlocksFromRoute($route);
         /** @var DocBlock $methodDocBlock */
@@ -112,13 +112,13 @@ class UseTransformerTags extends Strategy
 
     /**
      * @param array $tags
-     * @param ReflectionMethod $transformerMethod
+     * @param ReflectionFunctionAbstract $transformerMethod
      *
      * @throws Exception
      *
      * @return string
      */
-    private function getClassToBeTransformed(array $tags, ReflectionMethod $transformerMethod): string
+    private function getClassToBeTransformed(array $tags, ReflectionFunctionAbstract $transformerMethod): string
     {
         $modelTag = Arr::first(array_filter($tags, function ($tag) {
             return ($tag instanceof Tag) && strtolower($tag->getName()) == 'transformermodel';

--- a/src/Extracting/Strategies/Strategy.php
+++ b/src/Extracting/Strategies/Strategy.php
@@ -5,7 +5,7 @@ namespace Mpociot\ApiDoc\Extracting\Strategies;
 use Illuminate\Routing\Route;
 use Mpociot\ApiDoc\Tools\DocumentationConfig;
 use ReflectionClass;
-use ReflectionMethod;
+use ReflectionFunctionAbstract;
 
 abstract class Strategy
 {
@@ -28,7 +28,7 @@ abstract class Strategy
     /**
      * @param Route $route
      * @param ReflectionClass $controller
-     * @param ReflectionMethod $method
+     * @param ReflectionFunctionAbstract $method
      * @param array $routeRules Array of rules for the ruleset which this route belongs to.
      * @param array $context Results from the previous stages
      *
@@ -36,5 +36,5 @@ abstract class Strategy
      *
      * @return array
      */
-    abstract public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = []);
+    abstract public function __invoke(Route $route, ReflectionClass $controller, ReflectionFunctionAbstract $method, array $routeRules, array $context = []);
 }

--- a/src/Extracting/Strategies/UrlParameters/GetFromUrlParamTag.php
+++ b/src/Extracting/Strategies/UrlParameters/GetFromUrlParamTag.php
@@ -12,13 +12,13 @@ use Mpociot\ApiDoc\Extracting\Strategies\Strategy;
 use Mpociot\Reflection\DocBlock;
 use Mpociot\Reflection\DocBlock\Tag;
 use ReflectionClass;
-use ReflectionMethod;
+use ReflectionFunctionAbstract;
 
 class GetFromUrlParamTag extends Strategy
 {
     use ParamHelpers;
 
-    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
+    public function __invoke(Route $route, ReflectionClass $controller, ReflectionFunctionAbstract $method, array $routeRules, array $context = [])
     {
         foreach ($method->getParameters() as $param) {
             $paramType = $param->getType();

--- a/src/Tools/Utils.php
+++ b/src/Tools/Utils.php
@@ -5,6 +5,10 @@ namespace Mpociot\ApiDoc\Tools;
 use Illuminate\Routing\Route;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionFunction;
+use ReflectionFunctionAbstract;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\VarExporter\VarExporter;
@@ -25,13 +29,19 @@ class Utils
      */
     public static function getRouteClassAndMethodNames($routeOrAction)
     {
-        $action = $routeOrAction instanceof Route ? $routeOrAction->getAction() : $routeOrAction;
+        $action = $routeOrAction instanceof Route
+            ? $routeOrAction->getAction()
+            : $routeOrAction;
 
-        if ($action['uses'] !== null) {
-            if (is_array($action['uses'])) {
-                return $action['uses'];
-            } elseif (is_string($action['uses'])) {
-                return explode('@', $action['uses']);
+        $uses = $action['uses'];
+
+        if ($uses !== null) {
+            if (is_array($uses)) {
+                return $uses;
+            } elseif (is_string($uses)) {
+                return explode('@', $uses);
+            } elseif (static::isInvokableObject($uses)) {
+                return [$uses, '__invoke'];
             }
         }
         if (array_key_exists(0, $action) && array_key_exists(1, $action)) {
@@ -114,5 +124,33 @@ class Utils
         }
 
         return $result;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public static function isInvokableObject($value): bool
+    {
+        return is_object($value) && method_exists($value, '__invoke');
+    }
+
+    /**
+     * @param array $routeControllerAndMethod
+     *
+     * @throws ReflectionException
+     *
+     * @return ReflectionFunctionAbstract
+     */
+    public static function reflectRouteMethod(array $routeControllerAndMethod): ReflectionFunctionAbstract
+    {
+        [$class, $method] = $routeControllerAndMethod;
+
+        if ($class instanceof \Closure) {
+            return new ReflectionFunction($class);
+        }
+
+        return (new ReflectionClass($class))->getMethod($method);
     }
 }

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -55,7 +55,7 @@ class GenerateDocumentationTest extends TestCase
     }
 
     /** @test */
-    public function console_command_does_not_work_with_closure()
+    public function console_command_works_with_closure()
     {
         RouteFacade::get('/api/closure', function () {
             return 'hi';
@@ -65,12 +65,12 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.prefixes' => ['api/*']]);
         $output = $this->artisan('apidoc:generate');
 
-        $this->assertStringContainsString('Skipping route: [GET] api/closure', $output);
+        $this->assertStringContainsString('Processed route: [GET] api/closure', $output);
         $this->assertStringContainsString('Processed route: [GET] api/test', $output);
     }
 
     /** @test */
-    public function console_command_does_not_work_with_closure_using_dingo()
+    public function console_command_works_with_closure_using_dingo()
     {
         $api = app(\Dingo\Api\Routing\Router::class);
         $api->version('v1', function ($api) {
@@ -85,7 +85,7 @@ class GenerateDocumentationTest extends TestCase
         config(['apidoc.routes.0.match.versions' => ['v1']]);
         $output = $this->artisan('apidoc:generate');
 
-        $this->assertStringContainsString('Skipping route: [GET] closure', $output);
+        $this->assertStringContainsString('Processed route: [GET] closure', $output);
         $this->assertStringContainsString('Processed route: [GET] test', $output);
     }
 

--- a/tests/Unit/DingoGeneratorTest.php
+++ b/tests/Unit/DingoGeneratorTest.php
@@ -46,4 +46,16 @@ class DingoGeneratorTest extends GeneratorTestCase
 
         return $route;
     }
+
+    public function createRouteUsesCallable(string $httpMethod, string $path, callable $handler, $register = false)
+    {
+        $route = null;
+        /** @var Router $api */
+        $api = app(Router::class);
+        $api->version('v1', function (Router $api) use ($handler, $path, $httpMethod, &$route) {
+            $route = $api->$httpMethod($path, $handler);
+        });
+
+        return $route;
+    }
 }

--- a/tests/Unit/GeneratorTestCase.php
+++ b/tests/Unit/GeneratorTestCase.php
@@ -946,9 +946,37 @@ abstract class GeneratorTestCase extends TestCase
         $this->assertSame("This will be the long description.\nIt can also be multiple lines long.", $parsed['metadata']['description']);
     }
 
+    /** @test */
+    public function can_use_closure_in_routes_uses()
+    {
+        /**
+         * A short title.
+         * A longer description.
+         * Can be multiple lines.
+         *
+         * @queryParam location_id required The id of the location.
+         * @bodyParam name required Name of the location
+         */
+        $handler = function () {
+            return 'hi';
+        };
+        $route = $this->createRouteUsesCallable('GET', '/api/closure/test', $handler);
+
+        $parsed = $this->generator->processRoute($route);
+
+        $this->assertSame('A short title.', $parsed['metadata']['title']);
+        $this->assertSame("A longer description.\nCan be multiple lines.", $parsed['metadata']['description']);
+        $this->assertCount(1, $parsed['queryParameters']);
+        $this->assertCount(1, $parsed['bodyParameters']);
+        $this->assertSame('The id of the location.', $parsed['queryParameters']['location_id']['description']);
+        $this->assertSame('Name of the location', $parsed['bodyParameters']['name']['description']);
+    }
+
     abstract public function createRoute(string $httpMethod, string $path, string $controllerMethod, $register = false, $class = TestController::class);
 
     abstract public function createRouteUsesArray(string $httpMethod, string $path, string $controllerMethod, $register = false, $class = TestController::class);
+
+    abstract public function createRouteUsesCallable(string $httpMethod, string $path, callable $handler, $register = false);
 
     public function dataResources()
     {

--- a/tests/Unit/LaravelGeneratorTest.php
+++ b/tests/Unit/LaravelGeneratorTest.php
@@ -33,4 +33,13 @@ class LaravelGeneratorTest extends GeneratorTestCase
             return new Route([$httpMethod], $path, ['uses' => [$class, $controllerMethod]]);
         }
     }
+
+    public function createRouteUsesCallable(string $httpMethod, string $path, callable $handler, $register = false)
+    {
+        if ($register) {
+            return RouteFacade::{$httpMethod}($path, $handler);
+        } else {
+            return new Route([$httpMethod], $path, ['uses' => $handler]);
+        }
+    }
 }


### PR DESCRIPTION
This PR implements support for closures. The most significant change to the internal API is a move from `ReflectionMethod` to `ReflectionFunctionAbstract` in `Mpociot\ApiDoc\Extracting\Strategies\Strategy`.

This is a BC break so tell me if you need more tests. Any comments are appreciated.