### PR TITLE
Fix Postman collection url replacement

### DIFF
--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -283,7 +283,7 @@ class Writer
             $contents = str_replace('href="css/style.css"', 'href="/docs/css/style.css"', $contents);
             $contents = str_replace('src="js/all.js"', 'src="/docs/js/all.js"', $contents);
             $contents = str_replace('src="images/', 'src="/docs/images/', $contents);
-            $contents = preg_replace('#href="http://.+?/docs/collection.json"#', 'href="{{ route("apidoc", ["format" => ".json"]) }}"', $contents);
+            $contents = preg_replace('#href="https?://.+?/docs/collection.json"#', 'href="{{ route("apidoc", ["format" => ".json"]) }}"', $contents);
             file_put_contents("$this->outputPath/index.blade.php", $contents);
         }
     }


### PR DESCRIPTION
This PR fixes a small bug with a Postman collection URL inside `resources/views/apidoc/index.blade.php` when `apidoc.type` is `laravel` and `app.url` uses HTTPS protocol instead of HTTP.
This `<a href="https://localhost:8000/docs/collection.json">Get Postman Collection</a>` was not replaced to this `<a href="{{ route("apidoc", ["format" => ".json"]) }}">Get Postman Collection</a>`

I'm not sure either any additional tests are required for such a small fix.