### PR TITLE
Fix double JSON encode

### DIFF
--- a/src/Http/Controller.php
+++ b/src/Http/Controller.php
@@ -18,8 +18,6 @@ class Controller
      */
     public function json()
     {
-        return response()->json(
-            Storage::disk('local')->get('apidoc/collection.json')
-        );
+        return response(Storage::disk('local')->get('apidoc/collection.json'));
     }
 }


### PR DESCRIPTION
Currently you load a JSON string from `apidoc/collection.json`, and then encode it again. This will return the JSON straight away.