### PR TITLE
Fix double json encode

### DIFF
--- a/src/Http/Controller.php
+++ b/src/Http/Controller.php
@@ -18,8 +18,8 @@ class Controller
      */
     public function json()
     {
-        return response()->json(
-            Storage::disk('local')->get('apidoc/collection.json')
+        return response()->file(
+            Storage::disk('local')->path('apidoc/collection.json')
         );
     }
 }

--- a/src/Http/Controller.php
+++ b/src/Http/Controller.php
@@ -18,8 +18,8 @@ class Controller
      */
     public function json()
     {
-        return response()->file(
-            Storage::disk('local')->path('apidoc/collection.json')
+        return response()->json(
+            json_decode(Storage::disk('local')->get('apidoc/collection.json'))
         );
     }
 }


### PR DESCRIPTION
Currently you load a JSON string from `apidoc/collection.json`, and encode its content (string).
This results invalid response.

2 ways to fix:
1. decode the content from the JSON file first, then encode.
2. serve the file right away.

I implemented method 2, since it seems better.