### PR TITLE
Update ramsey/uuid's version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "mpociot/documentarian": "^0.4.0",
         "mpociot/reflection-docblock": "^1.0.1",
         "nunomaduro/collision": "^3.0|^4.0",
-        "ramsey/uuid": "^3.8|4.0",
+        "ramsey/uuid": "^3.8|^4.0",
         "symfony/var-exporter": "^4.0|^5.0"
     },
     "require-dev": {

--- a/dingo.composer.json
+++ b/dingo.composer.json
@@ -25,7 +25,7 @@
         "mpociot/documentarian": "^0.4.0",
         "mpociot/reflection-docblock": "^1.0.1",
         "nunomaduro/collision": "^3.0|^4.0",
-        "ramsey/uuid": "^3.8|4.0",
+        "ramsey/uuid": "^3.8|^4.0",
         "symfony/var-exporter": "^4.0|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Currently users that using `ramsey/uuid` version 4 can only install `ramsey/uuid:4.0.0`.

This change will allow users to upgrade `ramsey/uuid` to latest 4.x version.