### PR TITLE
Adding Laravel Vapor Support - Fixes #716

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -38,6 +38,13 @@ return [
     'router' => 'laravel',
 
     /*
+     * The storage to be used when generating assets.
+     * By default, uses 'local'. If you are using Laravel Vapor, please use S3 and make sure
+     * the correct bucket is correctly configured in the .env file
+     */
+    'storage' => 'local',
+
+    /*
      * The base URL to be used in examples and the Postman collection.
      * By default, this will be the value of config('app.url').
      */

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,4 @@ parameters:
         - '#(.*)NunoMaduro\\Collision(.*)#'
         - '#Instantiated class Whoops\\Exception\\Inspector not found\.#'
         - '#.+Dingo.+#'
-        - '#Call to an undefined Illuminate\Contracts\Filesystem\Filesystem::url()#'
+        - '#Call to an undefined method Illuminate\Contracts\Filesystem\Filesystem::url()#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,4 @@ parameters:
         - '#(.*)NunoMaduro\\Collision(.*)#'
         - '#Instantiated class Whoops\\Exception\\Inspector not found\.#'
         - '#.+Dingo.+#'
-        - '#Call to an undefined method Illuminate\Contracts\Filesystem\Filesystem::url()#'
+        - '#Call to an undefined method Illuminate\\Contracts\\Filesystem\\Filesystem::url()#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,3 +11,4 @@ parameters:
         - '#(.*)NunoMaduro\\Collision(.*)#'
         - '#Instantiated class Whoops\\Exception\\Inspector not found\.#'
         - '#.+Dingo.+#'
+        - '#Call to an undefined Illuminate\Contracts\Filesystem\Filesystem::url()#'

--- a/src/Http/Controller.php
+++ b/src/Http/Controller.php
@@ -19,7 +19,7 @@ class Controller
     public function json()
     {
         return response()->json(
-            json_decode(Storage::disk('local')->get('apidoc/collection.json'))
+            json_decode(Storage::disk(config('apidoc.storage'))->get('apidoc/collection.json'))
         );
     }
 }

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -206,8 +206,13 @@ class Writer
                 $collectionPath = "{$this->outputPath}/collection.json";
                 file_put_contents($collectionPath, $collection);
             } else {
-                Storage::disk('local')->put('apidoc/collection.json', $collection);
-                $collectionPath = 'storage/app/apidoc/collection.json';
+                $storageInstance = Storage::disk($this->config->get('storage'));
+                $storageInstance->put('apidoc/collection.json', $collection, 'public');
+                if ($this->config->get('storage') == 'local') {
+                    $collectionPath = 'storage/app/apidoc/collection.json';
+                } else {
+                    $collectionPath = $storageInstance->url('collection.json');
+                }
             }
 
             $this->output->info("Wrote Postman collection to: {$collectionPath}");
@@ -280,8 +285,8 @@ class Writer
             rename("{$this->sourceOutputPath}/index.html", "$this->outputPath/index.blade.php");
             $contents = file_get_contents("$this->outputPath/index.blade.php");
             //
-            $contents = str_replace('href="css/style.css"', 'href="/docs/css/style.css"', $contents);
-            $contents = str_replace('src="js/all.js"', 'src="/docs/js/all.js"', $contents);
+            $contents = str_replace('href="css/style.css"', 'href="{{ asset(\'/docs/css/style.css\') }}"', $contents);
+            $contents = str_replace('src="js/all.js"', 'src="{{ asset(\'/docs/js/all.js\') }}"', $contents);
             $contents = str_replace('src="images/', 'src="/docs/images/', $contents);
             $contents = preg_replace('#href="https?://.+?/docs/collection.json"#', 'href="{{ route("apidoc.json") }}"', $contents);
             file_put_contents("$this->outputPath/index.blade.php", $contents);


### PR DESCRIPTION
Hello, 

I added Laravel Vapor Support. 

The changes were relatively simple:

1. Adding a storage configuration variable so that users can choose the storage disk to use. In case of vapor, the users need to use S3
2. The calls to the`Storage` class now use the disk referenced in the config file.
3. Fixes the references to `all.css` and `all.js` to use the `asset()` function, since it generates a URL for an asset using the current scheme of the request (HTTP or HTTPS). In case of Vapor users, it will automatically reference the correct url for static files in AWS.