### PR TITLE
Support to change the output folder when generating static files

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -10,7 +10,7 @@ return [
     'type' => 'static',
 
     /*
-     * Static output folder: Uncomment and change it if you need the documentation to be generated in a different folder
+     * Static output folder: HTML documentation and assets will be generated in this folder.
      */
    'output_folder' => 'public/docs',
 

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -10,6 +10,11 @@ return [
     'type' => 'static',
 
     /*
+     * Static output folder: Uncomment and change it if you need the documentation to be generated in a different folder
+     */
+    // 'output_folder' => 'public/docs',
+
+    /*
      * Settings for `laravel` type output.
      */
     'laravel' => [

--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -12,7 +12,7 @@ return [
     /*
      * Static output folder: Uncomment and change it if you need the documentation to be generated in a different folder
      */
-    // 'output_folder' => 'public/docs',
+   'output_folder' => 'public/docs',
 
     /*
      * Settings for `laravel` type output.

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -66,7 +66,7 @@ class Writer
         $this->documentarian = new Documentarian();
         $this->isStatic = $this->config->get('type') === 'static';
         $this->sourceOutputPath = 'resources/docs';
-        $this->outputPath = $this->isStatic ? 'public/docs' : 'resources/views/apidoc';
+        $this->outputPath = $this->isStatic ? ($this->config->get('output_folder') ?? 'public/docs') : 'resources/views/apidoc';
     }
 
     public function writeDocs(Collection $routes)
@@ -252,7 +252,7 @@ class Writer
 
     protected function copyAssetsFromSourceFolderToPublicFolder(): void
     {
-        $publicPath = 'public/docs';
+        $publicPath = $this->config->get('output_folder') ?? 'public/docs';
         if (! is_dir($publicPath)) {
             mkdir($publicPath, 0777, true);
             mkdir("{$publicPath}/css");


### PR DESCRIPTION
Sometimes you need the static files to be generated in a folder different from public/docs, so I added a config parameter to change it.