### PR TITLE
Update Strategy.php

### DIFF
--- a/src/Extracting/Strategies/Strategy.php
+++ b/src/Extracting/Strategies/Strategy.php
@@ -34,7 +34,7 @@ abstract class Strategy
      *
      * @throws \Exception
      *
-     * @return array
+     * @return array|null
      */
     abstract public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = []);
 }


### PR DESCRIPTION
Allow **Strategy.php** to return null as a result of not applied strategy.

As documentation https://laravel-apidoc-generator.readthedocs.io/en/latest/plugins.html says that if a custom strategy can not be applied, **null should be returned**.

I checked **Generator** which i believe correctly checks for null results.