### PR TITLE
Add response parameter documentation

### DIFF
--- a/config/apidoc.php
+++ b/config/apidoc.php
@@ -219,6 +219,10 @@ return [
         'bodyParameters' => [
             \Mpociot\ApiDoc\Extracting\Strategies\BodyParameters\GetFromBodyParamTag::class,
         ],
+        'responseParameters' => [
+            \Mpociot\ApiDoc\Extracting\Strategies\ResponseParameters\GetFromResponseParamTag::class,
+            \Mpociot\ApiDoc\Extracting\Strategies\ResponseParameters\GetFromTransformerParamTag::class,
+        ],
         'responses' => [
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,
             \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseResponseTag::class,

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -341,6 +341,29 @@ public function getUser(int $id)
 }
 ```
 
+## Documenting parameters in responses
+
+Similarly to request parameters, you may provide documentation for response keys that get shown in a table in your docs.
+These are collected from `@responseParam` doc block tags that are collected from the controller method, or from the 
+`transform` or `__invoke` method in your configured transformer. Response parameter tags are written in the following 
+format:
+ 
+```
+@responseParam [param_name] [param_type] [description] [optional_example]
+```
+ 
+For example:
+
+```php
+/**
+ * @responseParam user_id int The id of the user. Example: 1
+ */
+public function getUser(int $id)
+{
+  // ...
+}
+```
+
 ## Generating responses automatically
 If you don't specify an example response using any of the above means, this package will attempt to get a sample response by making a request to the route (a "response call"). A few things to note about response calls:
 

--- a/resources/views/partials/route.blade.php
+++ b/resources/views/partials/route.blade.php
@@ -61,5 +61,15 @@ Parameter | Type | Status | Description
     `{{$attribute}}` | {{$parameter['type']}} | @if($parameter['required']) required @else optional @endif | {!! $parameter['description'] !!}
     @endforeach
 @endif
+@if(count($route['responseParameters']))
+
+#### Response Parameters
+
+Parameter | Type | Description
+--------- | ------- | ------- | ------- | -----------
+@foreach($route['responseParameters'] as $attribute => $parameter)
+    `{{$attribute}}` | {{$parameter['type']}} | {!! $parameter['description'] !!}
+@endforeach
+@endif
 
 <!-- END_{{$route['id']}} -->

--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -6,6 +6,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Mpociot\ApiDoc\Extracting\Strategies\ResponseParameters\GetFromResponseParamTag;
+use Mpociot\ApiDoc\Extracting\Strategies\ResponseParameters\GetFromTransformerParamTag;
 use Mpociot\ApiDoc\Tools\DocumentationConfig;
 use Mpociot\ApiDoc\Tools\Utils;
 use ReflectionClass;
@@ -164,7 +165,8 @@ class Generator
                 \Mpociot\ApiDoc\Extracting\Strategies\BodyParameters\GetFromBodyParamTag::class,
             ],
             'responseParameters' => [
-                GetFromResponseParamTag::class
+                GetFromResponseParamTag::class,
+                GetFromTransformerParamTag::class,
             ],
             'responses' => [
                 \Mpociot\ApiDoc\Extracting\Strategies\Responses\UseTransformerTags::class,

--- a/src/Extracting/Strategies/ResponseParameters/FromDocBlockHelper.php
+++ b/src/Extracting/Strategies/ResponseParameters/FromDocBlockHelper.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Mpociot\ApiDoc\Extracting\Strategies\ResponseParameters;
+
+use Mpociot\ApiDoc\Extracting\ParamHelpers;
+use Mpociot\Reflection\DocBlock\Tag;
+
+trait FromDocBlockHelper
+{
+    use ParamHelpers;
+
+    private function getResponseParametersFromDocBlock($tags)
+    {
+        $parameters = collect($tags)
+            ->filter(function ($tag) {
+                return $tag instanceof Tag && $tag->getName() === 'responseParam';
+            })
+            ->mapWithKeys(function (Tag $tag) {
+                // Format:
+                // @responseParam <name> <type> <description>
+                // Examples:
+                // @responseParam user_id integer The ID of the user.
+                preg_match('/(.+?)\s+(.+?)\s+(.*)/', $tag->getContent(), $content);
+                $content = preg_replace('/\s?No-example.?/', '', $content);
+                if (empty($content)) {
+                    // this means only name and type were supplied
+                    list($name, $type) = preg_split('/\s+/', $tag->getContent());
+                } else {
+                    list($_, $name, $type, $description) = $content;
+                    $description = trim($description);
+                }
+
+                $type = $this->normalizeParameterType($type);
+                list($description, $example) = $this->parseParamDescription($description, $type);
+                $value = is_null($example) && ! $this->shouldExcludeExample($tag->getContent())
+                    ? $this->generateDummyValue($type)
+                    : $example;
+
+                return [$name => compact('type', 'description', 'value')];
+            })->toArray();
+
+        return $parameters;
+    }
+}

--- a/src/Extracting/Strategies/ResponseParameters/FromDocBlockHelper.php
+++ b/src/Extracting/Strategies/ResponseParameters/FromDocBlockHelper.php
@@ -36,7 +36,7 @@ trait FromDocBlockHelper
                     ? $this->generateDummyValue($type)
                     : $example;
 
-                return [$name => compact('type', 'description', 'value')];
+                return [$name => compact('type', 'description', 'value', 'example')];
             })->toArray();
 
         return $parameters;

--- a/src/Extracting/Strategies/ResponseParameters/FromDocBlockHelper.php
+++ b/src/Extracting/Strategies/ResponseParameters/FromDocBlockHelper.php
@@ -22,6 +22,7 @@ trait FromDocBlockHelper
                 // @responseParam user_id integer The ID of the user.
                 preg_match('/(.+?)\s+(.+?)\s+(.*)/', $tag->getContent(), $content);
                 $content = preg_replace('/\s?No-example.?/', '', $content);
+                $description = '';
                 if (empty($content)) {
                     // this means only name and type were supplied
                     list($name, $type) = preg_split('/\s+/', $tag->getContent());

--- a/src/Extracting/Strategies/ResponseParameters/GetFromResponseParamTag.php
+++ b/src/Extracting/Strategies/ResponseParameters/GetFromResponseParamTag.php
@@ -5,17 +5,15 @@ namespace Mpociot\ApiDoc\Extracting\Strategies\ResponseParameters;
 use Dingo\Api\Http\FormRequest as DingoFormRequest;
 use Illuminate\Foundation\Http\FormRequest as LaravelFormRequest;
 use Illuminate\Routing\Route;
-use Mpociot\ApiDoc\Extracting\ParamHelpers;
 use Mpociot\ApiDoc\Extracting\RouteDocBlocker;
 use Mpociot\ApiDoc\Extracting\Strategies\Strategy;
 use Mpociot\Reflection\DocBlock;
-use Mpociot\Reflection\DocBlock\Tag;
 use ReflectionClass;
 use ReflectionMethod;
 
 class GetFromResponseParamTag extends Strategy
 {
-    use ParamHelpers;
+    use FromDocBlockHelper;
 
     public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
     {
@@ -37,7 +35,7 @@ class GetFromResponseParamTag extends Strategy
             if (class_exists(LaravelFormRequest::class) && $parameterClass->isSubclassOf(LaravelFormRequest::class)
                 || class_exists(DingoFormRequest::class) && $parameterClass->isSubclassOf(DingoFormRequest::class)) {
                 $formRequestDocBlock = new DocBlock($parameterClass->getDocComment());
-                $bodyParametersFromDocBlock = $this->getBodyParametersFromDocBlock($formRequestDocBlock->getTags());
+                $bodyParametersFromDocBlock = $this->getResponseParametersFromDocBlock($formRequestDocBlock->getTags());
 
                 if (count($bodyParametersFromDocBlock)) {
                     return $bodyParametersFromDocBlock;
@@ -48,39 +46,6 @@ class GetFromResponseParamTag extends Strategy
         /** @var DocBlock $methodDocBlock */
         $methodDocBlock = RouteDocBlocker::getDocBlocksFromRoute($route)['method'];
 
-        return $this->getBodyParametersFromDocBlock($methodDocBlock->getTags());
-    }
-
-    private function getBodyParametersFromDocBlock($tags)
-    {
-        $parameters = collect($tags)
-            ->filter(function ($tag) {
-                return $tag instanceof Tag && $tag->getName() === 'responseParam';
-            })
-            ->mapWithKeys(function (Tag $tag) {
-                // Format:
-                // @responseParam <name> <type> <description>
-                // Examples:
-                // @responseParam user_id integer The ID of the user.
-                preg_match('/(.+?)\s+(.+?)\s+(.*)/', $tag->getContent(), $content);
-                $content = preg_replace('/\s?No-example.?/', '', $content);
-                if (empty($content)) {
-                    // this means only name and type were supplied
-                    list($name, $type) = preg_split('/\s+/', $tag->getContent());
-                } else {
-                    list($_, $name, $type, $description) = $content;
-                    $description = trim($description);
-                }
-
-                $type = $this->normalizeParameterType($type);
-                list($description, $example) = $this->parseParamDescription($description, $type);
-                $value = is_null($example) && ! $this->shouldExcludeExample($tag->getContent())
-                    ? $this->generateDummyValue($type)
-                    : $example;
-
-                return [$name => compact('type', 'description', 'value')];
-            })->toArray();
-
-        return $parameters;
+        return $this->getResponseParametersFromDocBlock($methodDocBlock->getTags());
     }
 }

--- a/src/Extracting/Strategies/ResponseParameters/GetFromResponseParamTag.php
+++ b/src/Extracting/Strategies/ResponseParameters/GetFromResponseParamTag.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Mpociot\ApiDoc\Extracting\Strategies\ResponseParameters;
+
+use Dingo\Api\Http\FormRequest as DingoFormRequest;
+use Illuminate\Foundation\Http\FormRequest as LaravelFormRequest;
+use Illuminate\Routing\Route;
+use Mpociot\ApiDoc\Extracting\ParamHelpers;
+use Mpociot\ApiDoc\Extracting\RouteDocBlocker;
+use Mpociot\ApiDoc\Extracting\Strategies\Strategy;
+use Mpociot\Reflection\DocBlock;
+use Mpociot\Reflection\DocBlock\Tag;
+use ReflectionClass;
+use ReflectionMethod;
+
+class GetFromResponseParamTag extends Strategy
+{
+    use ParamHelpers;
+
+    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
+    {
+        foreach ($method->getParameters() as $param) {
+            $paramType = $param->getType();
+            if ($paramType === null) {
+                continue;
+            }
+
+            $parameterClassName = $paramType->getName();
+
+            try {
+                $parameterClass = new ReflectionClass($parameterClassName);
+            } catch (\ReflectionException $e) {
+                continue;
+            }
+
+            // If there's a FormRequest, we check there for @bodyParam tags.
+            if (class_exists(LaravelFormRequest::class) && $parameterClass->isSubclassOf(LaravelFormRequest::class)
+                || class_exists(DingoFormRequest::class) && $parameterClass->isSubclassOf(DingoFormRequest::class)) {
+                $formRequestDocBlock = new DocBlock($parameterClass->getDocComment());
+                $bodyParametersFromDocBlock = $this->getBodyParametersFromDocBlock($formRequestDocBlock->getTags());
+
+                if (count($bodyParametersFromDocBlock)) {
+                    return $bodyParametersFromDocBlock;
+                }
+            }
+        }
+
+        /** @var DocBlock $methodDocBlock */
+        $methodDocBlock = RouteDocBlocker::getDocBlocksFromRoute($route)['method'];
+
+        return $this->getBodyParametersFromDocBlock($methodDocBlock->getTags());
+    }
+
+    private function getBodyParametersFromDocBlock($tags)
+    {
+        $parameters = collect($tags)
+            ->filter(function ($tag) {
+                return $tag instanceof Tag && $tag->getName() === 'responseParam';
+            })
+            ->mapWithKeys(function (Tag $tag) {
+                // Format:
+                // @responseParam <name> <type> <description>
+                // Examples:
+                // @responseParam user_id integer The ID of the user.
+                preg_match('/(.+?)\s+(.+?)\s+(.*)/', $tag->getContent(), $content);
+                $content = preg_replace('/\s?No-example.?/', '', $content);
+                if (empty($content)) {
+                    // this means only name and type were supplied
+                    list($name, $type) = preg_split('/\s+/', $tag->getContent());
+                } else {
+                    list($_, $name, $type, $description) = $content;
+                    $description = trim($description);
+                }
+
+                $type = $this->normalizeParameterType($type);
+                list($description, $example) = $this->parseParamDescription($description, $type);
+                $value = is_null($example) && ! $this->shouldExcludeExample($tag->getContent())
+                    ? $this->generateDummyValue($type)
+                    : $example;
+
+                return [$name => compact('type', 'description', 'value')];
+            })->toArray();
+
+        return $parameters;
+    }
+}

--- a/src/Extracting/Strategies/ResponseParameters/GetFromTransformerParamTag.php
+++ b/src/Extracting/Strategies/ResponseParameters/GetFromTransformerParamTag.php
@@ -30,18 +30,18 @@ class GetFromTransformerParamTag extends Strategy
         [$statusCode, $transformer] = $this->getStatusCodeAndTransformerClass($tag);
 
         // Reflect the transformer
-        $relection = new ReflectionClass($transformer);
+        $reflection = new ReflectionClass($transformer);
         $method = 'transform';
 
-        if (!$relection->hasMethod('transform')) {
+        if (!$reflection->hasMethod('transform')) {
             $method = '__invoke';
         }
-        if (!$relection->hasMethod($method)) {
+        if (!$reflection->hasMethod($method)) {
             return null;
         }
 
         return $this->getResponseParametersFromDocBlock(
-            (new DocBlock($relection->getMethod($method)->getDocComment() ?: ''))->getTags()
+            (new DocBlock($reflection->getMethod($method)->getDocComment() ?: ''))->getTags()
         );
     }
 }

--- a/src/Extracting/Strategies/ResponseParameters/GetFromTransformerParamTag.php
+++ b/src/Extracting/Strategies/ResponseParameters/GetFromTransformerParamTag.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mpociot\ApiDoc\Extracting\Strategies\ResponseParameters;
+
+use Illuminate\Routing\Route;
+use Mpociot\ApiDoc\Extracting\RouteDocBlocker;
+use Mpociot\ApiDoc\Extracting\Strategies\Strategy;
+use Mpociot\ApiDoc\Extracting\TransformerHelpers;
+use Mpociot\Reflection\DocBlock;
+use ReflectionClass;
+use ReflectionMethod;
+
+class GetFromTransformerParamTag extends Strategy
+{
+    use FromDocBlockHelper;
+    use TransformerHelpers;
+
+    public function __invoke(Route $route, ReflectionClass $controller, ReflectionMethod $method, array $routeRules, array $context = [])
+    {
+        $docBlocks = RouteDocBlocker::getDocBlocksFromRoute($route);
+        /** @var DocBlock $methodDocBlock */
+        $methodDocBlock = $docBlocks['method'];
+
+        $tag = $this->getTransformerTag($methodDocBlock->getTags());
+
+        if (empty($tag)) {
+            return null;
+        }
+
+        [$statusCode, $transformer] = $this->getStatusCodeAndTransformerClass($tag);
+
+        // Reflect the transformer
+        $relection = new ReflectionClass($transformer);
+        $method = 'transform';
+
+        if (!$relection->hasMethod('transform')) {
+            $method = '__invoke';
+        }
+        if (!$relection->hasMethod($method)) {
+            return null;
+        }
+
+        return $this->getResponseParametersFromDocBlock(
+            (new DocBlock($relection->getMethod($method)->getDocComment() ?: ''))->getTags()
+        );
+    }
+}

--- a/src/Extracting/Strategies/Responses/UseTransformerTags.php
+++ b/src/Extracting/Strategies/Responses/UseTransformerTags.php
@@ -12,6 +12,7 @@ use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use Mpociot\ApiDoc\Extracting\RouteDocBlocker;
 use Mpociot\ApiDoc\Extracting\Strategies\Strategy;
+use Mpociot\ApiDoc\Extracting\TransformerHelpers;
 use Mpociot\ApiDoc\Tools\Flags;
 use Mpociot\ApiDoc\Tools\Utils;
 use Mpociot\Reflection\DocBlock;
@@ -24,6 +25,8 @@ use ReflectionMethod;
  */
 class UseTransformerTags extends Strategy
 {
+    use TransformerHelpers;
+
     /**
      * @param Route $route
      * @param ReflectionClass $controller
@@ -94,108 +97,5 @@ class UseTransformerTags extends Strategy
 
             return null;
         }
-    }
-
-    /**
-     * @param Tag $tag
-     *
-     * @return array
-     */
-    private function getStatusCodeAndTransformerClass($tag): array
-    {
-        $content = $tag->getContent();
-        preg_match('/^(\d{3})?\s?([\s\S]*)$/', $content, $result);
-        $status = $result[1] ?: 200;
-        $transformerClass = $result[2];
-
-        return [$status, $transformerClass];
-    }
-
-    /**
-     * @param array $tags
-     * @param ReflectionMethod $transformerMethod
-     *
-     * @throws Exception
-     *
-     * @return string
-     */
-    private function getClassToBeTransformed(array $tags, ReflectionMethod $transformerMethod): string
-    {
-        $modelTag = Arr::first(array_filter($tags, function ($tag) {
-            return ($tag instanceof Tag) && strtolower($tag->getName()) == 'transformermodel';
-        }));
-
-        $type = null;
-        if ($modelTag) {
-            $type = $modelTag->getContent();
-        } else {
-            $parameter = Arr::first($transformerMethod->getParameters());
-            if ($parameter->hasType() && ! $parameter->getType()->isBuiltin() && class_exists($parameter->getType()->getName())) {
-                // Ladies and gentlemen, we have a type!
-                $type = $parameter->getType()->getName();
-            }
-        }
-
-        if ($type == null) {
-            throw new Exception('Failed to detect a transformer model. Please specify a model using @transformerModel.');
-        }
-
-        return $type;
-    }
-
-    /**
-     * @param string $type
-     *
-     * @return Model|object
-     */
-    protected function instantiateTransformerModel(string $type)
-    {
-        try {
-            // try Eloquent model factory
-
-            // Factories are usually defined without the leading \ in the class name,
-            // but the user might write it that way in a comment. Let's be safe.
-            $type = ltrim($type, '\\');
-
-            return factory($type)->make();
-        } catch (Exception $e) {
-            if (Flags::$shouldBeVerbose) {
-                echo "Eloquent model factory failed to instantiate {$type}; trying to fetch from database.\n";
-            }
-
-            $instance = new $type();
-            if ($instance instanceof IlluminateModel) {
-                try {
-                    // we can't use a factory but can try to get one from the database
-                    $firstInstance = $type::first();
-                    if ($firstInstance) {
-                        return $firstInstance;
-                    }
-                } catch (Exception $e) {
-                    // okay, we'll stick with `new`
-                    if (Flags::$shouldBeVerbose) {
-                        echo "Failed to fetch first {$type} from database; using `new` to instantiate.\n";
-                    }
-                }
-            }
-        }
-
-        return $instance;
-    }
-
-    /**
-     * @param array $tags
-     *
-     * @return Tag|null
-     */
-    private function getTransformerTag(array $tags)
-    {
-        $transformerTags = array_values(
-            array_filter($tags, function ($tag) {
-                return ($tag instanceof Tag) && in_array(strtolower($tag->getName()), ['transformer', 'transformercollection']);
-            })
-        );
-
-        return Arr::first($transformerTags);
     }
 }

--- a/src/Extracting/TransformerHelpers.php
+++ b/src/Extracting/TransformerHelpers.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Mpociot\ApiDoc\Extracting;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as IlluminateModel;
+use Illuminate\Support\Arr;
+use Mpociot\ApiDoc\Tools\Flags;
+use Mpociot\Reflection\DocBlock\Tag;
+use ReflectionMethod;
+
+trait TransformerHelpers
+{
+    /**
+     * @param Tag $tag
+     *
+     * @return array
+     */
+    private function getStatusCodeAndTransformerClass($tag): array
+    {
+        $content = $tag->getContent();
+        preg_match('/^(\d{3})?\s?([\s\S]*)$/', $content, $result);
+        $status = $result[1] ?: 200;
+        $transformerClass = $result[2];
+
+        return [$status, $transformerClass];
+    }
+
+    /**
+     * @param array $tags
+     * @param ReflectionMethod $transformerMethod
+     *
+     * @throws Exception
+     *
+     * @return string
+     */
+    private function getClassToBeTransformed(array $tags, ReflectionMethod $transformerMethod): string
+    {
+        $modelTag = Arr::first(array_filter($tags, function ($tag) {
+            return ($tag instanceof Tag) && strtolower($tag->getName()) == 'transformermodel';
+        }));
+
+        $type = null;
+        if ($modelTag) {
+            $type = $modelTag->getContent();
+        } else {
+            $parameter = Arr::first($transformerMethod->getParameters());
+            if ($parameter->hasType() && ! $parameter->getType()->isBuiltin() && class_exists($parameter->getType()->getName())) {
+                // Ladies and gentlemen, we have a type!
+                $type = $parameter->getType()->getName();
+            }
+        }
+
+        if ($type == null) {
+            throw new Exception('Failed to detect a transformer model. Please specify a model using @transformerModel.');
+        }
+
+        return $type;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return Model|object
+     */
+    protected function instantiateTransformerModel(string $type)
+    {
+        try {
+            // try Eloquent model factory
+
+            // Factories are usually defined without the leading \ in the class name,
+            // but the user might write it that way in a comment. Let's be safe.
+            $type = ltrim($type, '\\');
+
+            return factory($type)->make();
+        } catch (Exception $e) {
+            if (Flags::$shouldBeVerbose) {
+                echo "Eloquent model factory failed to instantiate {$type}; trying to fetch from database.\n";
+            }
+
+            $instance = new $type();
+            if ($instance instanceof IlluminateModel) {
+                try {
+                    // we can't use a factory but can try to get one from the database
+                    $firstInstance = $type::first();
+                    if ($firstInstance) {
+                        return $firstInstance;
+                    }
+                } catch (Exception $e) {
+                    // okay, we'll stick with `new`
+                    if (Flags::$shouldBeVerbose) {
+                        echo "Failed to fetch first {$type} from database; using `new` to instantiate.\n";
+                    }
+                }
+            }
+        }
+
+        return $instance;
+    }
+
+    /**
+     * @param array $tags
+     *
+     * @return Tag|null
+     */
+    private function getTransformerTag(array $tags)
+    {
+        $transformerTags = array_values(
+            array_filter($tags, function ($tag) {
+                return ($tag instanceof Tag) && in_array(strtolower($tag->getName()), ['transformer', 'transformercollection']);
+            })
+        );
+
+        return Arr::first($transformerTags);
+    }
+}


### PR DESCRIPTION
I've added a little section in the docs that describes this, but it works very similarly to the various request documentation options.

I've added collection from controller methods, but also from transformers, as that reduces the effort required to document if you use the same transformer in multiple places. It _doesn't_ handle transformers within transformers (if you're using includes), although I might look to add that in another PR in the future.