### PR TITLE
Updated default empty description for body params

### DIFF
--- a/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
@@ -69,13 +69,13 @@ class GetFromBodyParamTag extends Strategy
                     // this means only name and type were supplied
                     list($name, $type) = preg_split('/\s+/', $tag->getContent());
                     $required = false;
-                    $description = $this->formatNameAsDescription($name);
+                    $description = '';
                 } else {
                     list($_, $name, $type, $required, $description) = $content;
                     $description = trim($description);
                     if ($description == 'required' && empty(trim($required))) {
                         $required = $description;
-                        $description = $this->formatNameAsDescription($name);
+                        $description = '';
                     }
                     $required = trim($required) == 'required' ? true : false;
                 }
@@ -86,14 +86,13 @@ class GetFromBodyParamTag extends Strategy
                     ? $this->generateDummyValue($type)
                     : $example;
 
+                if (empty($description)) {
+                    $description = ucfirst(implode(' ', explode('_', $name)));
+                }
+
                 return [$name => compact('type', 'description', 'required', 'value')];
             })->toArray();
 
         return $parameters;
-    }
-
-    private function formatNameAsDescription(string $name)
-    {
-        return ucfirst(implode(' ', explode('_', $name)));
     }
 }

--- a/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
@@ -69,7 +69,7 @@ class GetFromBodyParamTag extends Strategy
                     // this means only name and type were supplied
                     list($name, $type) = preg_split('/\s+/', $tag->getContent());
                     $required = false;
-                    $description = '';
+                    $description = ucfirst(implode(' ', explode('_', $name)));
                 } else {
                     list($_, $name, $type, $required, $description) = $content;
                     $description = trim($description);

--- a/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
@@ -69,13 +69,13 @@ class GetFromBodyParamTag extends Strategy
                     // this means only name and type were supplied
                     list($name, $type) = preg_split('/\s+/', $tag->getContent());
                     $required = false;
-                    $description = $this->nameToDescription($name);
+                    $description = $this->formatNameAsDescription($name);
                 } else {
                     list($_, $name, $type, $required, $description) = $content;
                     $description = trim($description);
                     if ($description == 'required' && empty(trim($required))) {
                         $required = $description;
-                        $description = $this->nameToDescription($name);
+                        $description = $this->formatNameAsDescription($name);
                     }
                     $required = trim($required) == 'required' ? true : false;
                 }

--- a/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
@@ -69,13 +69,13 @@ class GetFromBodyParamTag extends Strategy
                     // this means only name and type were supplied
                     list($name, $type) = preg_split('/\s+/', $tag->getContent());
                     $required = false;
-                    $description = ucfirst(implode(' ', explode('_', $name)));
+                    $description = $this->nameToDescription($name);
                 } else {
                     list($_, $name, $type, $required, $description) = $content;
                     $description = trim($description);
                     if ($description == 'required' && empty(trim($required))) {
                         $required = $description;
-                        $description = '';
+                        $description = $this->nameToDescription($name);
                     }
                     $required = trim($required) == 'required' ? true : false;
                 }
@@ -90,5 +90,10 @@ class GetFromBodyParamTag extends Strategy
             })->toArray();
 
         return $parameters;
+    }
+
+    private function formatNameAsDescription(string $name)
+    {
+        return ucfirst(implode(' ', explode('_', $name)));
     }
 }


### PR DESCRIPTION
After having a play with the project - which is brilliant, it seems logical to me to take the default parameter names and explode them out to provide a default description. This way for a majority of fields no description has to be provided unless the user chooses to override this value.

Before:

![image](https://user-images.githubusercontent.com/2487374/90260865-0fa78280-de44-11ea-87ac-f2a4b8ab4171.png)


After:

![image](https://user-images.githubusercontent.com/2487374/90260902-1cc47180-de44-11ea-9586-774b1f7a175a.png)

I hope you can see a use for this! Thanks.
