### PR TITLE
Set the options' language parameter to json in request body

### DIFF
--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -84,6 +84,11 @@ class PostmanCollectionWriter
                 'body' => [
                     'mode' => $mode,
                     $mode => json_encode($route['cleanBodyParameters'], JSON_PRETTY_PRINT),
+                    "options" => [
+                        $mode => [
+                            "language" => "json"
+                        ]
+                    ],
                 ],
                 'description' => $route['metadata']['description'] ?? null,
                 'response' => [],


### PR DESCRIPTION
The package generates JSON collections, where request body mode is set to row, but language isn't set. 
So, when we import collections, Postman sets body to raw "text".
This pull request adds the "language" option set to "json".
