### PR TITLE
Adjustments

### DIFF
--- a/src/Tools/Utils.php
+++ b/src/Tools/Utils.php
@@ -131,8 +131,9 @@ class Utils
                     $qs .= "$paramName" . '[]=' . urlencode($value[0]) . '&';
                 } else {
                     foreach ($value as $item => $itemValue) {
-                        if(!is_array($itemValue))
+                        if (!is_array($itemValue)) {
                             continue;
+                        }
 
                         $return = self::recursiveItemValue("[$item]", $itemValue);
 
@@ -157,17 +158,17 @@ class Utils
     {
         $item_values = [];
 
-        if(is_array($item_value)) {
+        if (is_array($item_value)) {
             foreach ($item_value as $key => $value) {
                 $item_values = array_merge(
-                    $item_values, 
+                    $item_values,
                     self::recursiveItemValue(
-                        sprintf("%s[%s]", $item, $key), 
+                        sprintf("%s[%s]", $item, $key),
                         $value
                     )
                 );
             }
-        }else{
+        } else {
             return [$item => $item_value];
         }
 
@@ -195,8 +196,9 @@ class Utils
                 } else {
                     // Hash query param (eg filter[name]=john should become "filter[name]": "john")
                     foreach ($value as $item => $itemValue) {
-                        if(!is_array($itemValue))
+                        if (!is_array($itemValue)) {
                             continue;
+                        }
 
                         $return = self::recursiveItemValue("[$item]", $itemValue);
 


### PR DESCRIPTION
I found some errors in rendering multidimensional array params such as "param[with][array][]".
When I've tried to execute the command `PHP artisan apidoc` the following is shown:
```
ErrorException  : Array to string conversion (View: /path/to/application/vendor/mpociot/laravel-apidoc-generator/resources/views/partials/example-requests/php.blade.php) (View: /path/to/application/vendor/mpociot/laravel-apidoc-generator/resources/views/partials/example-requests/php.blade.php)
  at /path/to/application/vendor/mpociot/laravel-apidoc-generator/src/Tools/Utils.php:166
    162|                 } else {
    163|                     // Hash query param (eg filter[name]=john should become "filter[name]": "john")
    164|                     foreach ($value as $item => $itemValue) {
    165|                         $output .= str_repeat(" ", $spacesIndentation);
  > 166|                         $output .= "$quote$parameter" . "[$item]$quote$delimiter $quote$itemValue$quote,\n";
    167|                     }
    168|                 }
    169|             }
    170|         }
  Exception trace:
  1   Illuminate\View\Engines\CompilerEngine::handleViewException()
      /path/to/application/vendor/laravel/framework/src/Illuminate/View/Engines/PhpEngine.php:45
  2   Mpociot\ApiDoc\Writing\Writer::Mpociot\ApiDoc\Writing\{closure}()
      [internal]:0
```