### PR TITLE
fix the way unicode character are displayed in generated responses in…

### DIFF
--- a/resources/views/partials/example-requests/bash.blade.php
+++ b/resources/views/partials/example-requests/bash.blade.php
@@ -7,7 +7,7 @@ curl -X {{$route['methods'][0]}} \
 @endforeach
 @endif
 @if(count($route['cleanBodyParameters']))
-    -d '{!! json_encode($route['cleanBodyParameters']) !!}'
+    -d '{!! json_encode($route['cleanBodyParameters'], JSON_UNESCAPED_UNICODE) !!}'
 @endif
 
 ```

--- a/resources/views/partials/example-requests/javascript.blade.php
+++ b/resources/views/partials/example-requests/javascript.blade.php
@@ -24,7 +24,7 @@ let headers = {
 @endif
 @if(count($route['cleanBodyParameters']))
 
-let body = {!! json_encode($route['cleanBodyParameters'], JSON_PRETTY_PRINT) !!}
+let body = {!! json_encode($route['cleanBodyParameters'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) !!}
 @endif
 
 fetch(url, {

--- a/resources/views/partials/example-requests/php.blade.php
+++ b/resources/views/partials/example-requests/php.blade.php
@@ -20,5 +20,5 @@ $response = $client->{{ strtolower($route['methods'][0]) }}(
 $response = $client->{{ strtolower($route['methods'][0]) }}('{{ rtrim($baseUrl, '/') . '/' . ltrim($route['boundUri'], '/') }}');
 @endif
 $body = $response->getBody();
-print_r(json_decode((string) $body));
+print_r(json_decode((string) $body, JSON_UNESCAPED_UNICODE));
 ```

--- a/resources/views/partials/example-requests/python.blade.php
+++ b/resources/views/partials/example-requests/python.blade.php
@@ -4,7 +4,7 @@ import json
 
 url = '{{ rtrim($baseUrl, '/') }}/{{ ltrim($route['boundUri'], '/') }}'
 @if(count($route['cleanBodyParameters']))
-payload = {!! json_encode($route['cleanBodyParameters'], JSON_PRETTY_PRINT) !!}
+payload = {!! json_encode($route['cleanBodyParameters'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) !!}
 @endif
 @if(count($route['cleanQueryParameters']))
 params = {!! \Mpociot\ApiDoc\Tools\Utils::printQueryParamsAsKeyValue($route['cleanQueryParameters'], "'", ":", 2, "{}") !!}


### PR DESCRIPTION
A little change, to show correct unicode characters that example responses might have instead of the way the are now in escaped.

For example:
```json
{"name":"\u0627\u0628\u0631\u0627\u0647\u06cc\u0645"}
```
should be displayed as : 
```json
{"name":"ابراهیم"}
```
to be readable in documents.