### PR TITLE
[Bugfix] Ensure updated `$context` gets passed through

### DIFF
--- a/src/Tools/Generator.php
+++ b/src/Tools/Generator.php
@@ -143,7 +143,10 @@ class Generator
         $context[$stage] = $context[$stage] ?? [];
         foreach ($strategies as $strategyClass) {
             $strategy = new $strategyClass($stage, $this->config);
-            $arguments[] = $context;
+
+            // The `Strategy` class expects the $context array as the 5th position, or array key 4
+            $contextPosition = 4;
+            $arguments[$contextPosition] = $context;
             $results = $strategy(...$arguments);
             if (! is_null($results)) {
                 foreach ($results as $index => $item) {


### PR DESCRIPTION
- When there are several items in the stage, appending the current `$context` onto the `$arguments` will not update it
- As per c3cc56177f, if a previous `$context['responses']` is set, do not continue making calls further strategies
- If we simply append the current `$context` onto the `$arguments`, the param that gets resolved inside of the `Strategy` is not updated
  * Thus the check for "Don't attempt a response call if there are already responses" is always `false`