### PR TITLE
[Bug] Take output path from configuration when building "apidoc::partials.info" partial

### DIFF
--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -95,7 +95,7 @@ class Writer
         $compareFile = $this->sourceOutputPath . '/source/.compare.md';
 
         $infoText = view('apidoc::partials.info')
-            ->with('outputPath', 'docs')
+            ->with('outputPath', $this->config->get('output'))
             ->with('showPostmanCollectionButton', $this->shouldGeneratePostmanCollection);
 
         $settings = ['languages' => $this->config->get('example_languages')];


### PR DESCRIPTION
The `apidoc::partials.info` partial contains the link to Postman generated documentation, but it always outputs the link at `/docs/collection.json`, no matter the actual output folder that's configured.

This bugfix should output the **link to Postman collection** to whatever the output is configured at.