### PR TITLE
fix: responseFile convert empty object to array

### DIFF
--- a/src/Extracting/Strategies/Responses/UseResponseFileTag.php
+++ b/src/Extracting/Strategies/Responses/UseResponseFileTag.php
@@ -62,7 +62,12 @@ class UseResponseFileTag extends Strategy
             }
             $status = $result[1] ?: 200;
             $content = $result[2] ? file_get_contents($filePath, true) : '{}';
-            $json = ! empty($result[3]) ? str_replace("'", '"', $result[3]) : '{}';
+
+            if (empty($result[3])) {
+              return ['content' => $content, 'status' => (int) $status];
+            }
+
+            $json = str_replace("'", '"', $result[3]);
             $merged = array_merge(json_decode($content, true), json_decode($json, true));
 
             return ['content' => json_encode($merged), 'status' => (int) $status];


### PR DESCRIPTION
responseFile convert empty object to array due to `json_decode($content, true)`
Example
```json
{"foo":{}}
```
convert to
```json
{"foo":[]}
```